### PR TITLE
Add graceful stopping for retroarch on shutdown

### DIFF
--- a/device/rg35xx-sp/input/trigger/sleep.sh
+++ b/device/rg35xx-sp/input/trigger/sleep.sh
@@ -3,6 +3,7 @@
 . /opt/muos/script/system/parse.sh
 CONFIG=/opt/muos/config/config.ini
 
+FG_PROC="/tmp/fg_proc"
 SLEEP_STATE="/tmp/sleep_state"
 SLEEP_TIMER="/tmp/sleep_timer"
 LOG_FILE="/tmp/mushutdown_log.txt"
@@ -27,6 +28,13 @@ while true; do
 	if [ "$SLEEP_TIMER_VAL" -eq "$MUX_SLEEP" ]; then
 		echo "Attempting to shutdown at $(date)" >> "$LOG_FILE"
 		echo 1 > /sys/class/power_supply/axp2202-battery/moto && sleep 0.25 && echo 0 > /sys/class/power_supply/axp2202-battery/moto
+		FG_PROC_VAL=$(cat "$FG_PROC")
+		if pidof "$FG_PROC_VAL" > /dev/null; then
+			pkill -CONT "$FG_PROC_VAL"
+			if [ "$FG_PROC_VAL" = "retroarch" ]; then
+				pkill "$FG_PROC_VAL"
+			fi
+		fi
 		$MUSHUTDOWN_CMD >> "$LOG_FILE" 2>&1
 		if [ $? -ne 0 ]; then
 			echo "Shutdown failed at $(date)" >> "$LOG_FILE"

--- a/device/rg35xx-sp/input/trigger/sleep.sh
+++ b/device/rg35xx-sp/input/trigger/sleep.sh
@@ -33,6 +33,7 @@ while true; do
 			pkill -CONT "$FG_PROC_VAL"
 			if [ "$FG_PROC_VAL" = "retroarch" ]; then
 				pkill "$FG_PROC_VAL"
+                sleep 1  # leave some time for launch.sh to finish some tasks
 			fi
 		fi
 		$MUSHUTDOWN_CMD >> "$LOG_FILE" 2>&1


### PR DESCRIPTION
Need to `CONT` and `kill` it gracefully before shutting down so that it can do its autosaving stuff.

Also added a small sleep after closing RA, so that `launch.sh` can finish at least some of it's tasks, like saving the last played game.