### PR TITLE
Inititalise pdi_go

### DIFF
--- a/script/system/startup.sh
+++ b/script/system/startup.sh
@@ -138,5 +138,6 @@ fi
 
 /opt/muos/script/mux/configbackup.sh &
 
+touch /tmp/pdi_go
 /opt/muos/script/mux/frontend.sh &
 


### PR DESCRIPTION
Fix for Explore Content not be accessible on boot.