### PR TITLE
Lower up threshold and sampling down factor

### DIFF
--- a/device/rg28xx/config.ini
+++ b/device/rg28xx/config.ini
@@ -69,8 +69,8 @@ up_threshold=/sys/devices/system/cpu/cpufreq/ondemand/up_threshold
 sampling_down_factor=/sys/devices/system/cpu/cpufreq/ondemand/sampling_down_factor
 io_is_busy=/sys/devices/system/cpu/cpufreq/ondemand/io_is_busy
 sampling_rate_default=200000
-up_threshold_default=78
-sampling_down_factor_default=10
+up_threshold_default=55
+sampling_down_factor_default=5
 io_is_busy_default=1
 
 [network]

--- a/device/rg35xx-2024/config.ini
+++ b/device/rg35xx-2024/config.ini
@@ -69,8 +69,8 @@ up_threshold=/sys/devices/system/cpu/cpufreq/ondemand/up_threshold
 sampling_down_factor=/sys/devices/system/cpu/cpufreq/ondemand/sampling_down_factor
 io_is_busy=/sys/devices/system/cpu/cpufreq/ondemand/io_is_busy
 sampling_rate_default=200000
-up_threshold_default=78
-sampling_down_factor_default=10
+up_threshold_default=55
+sampling_down_factor_default=5
 io_is_busy_default=1
 
 [network]

--- a/device/rg35xx-h/config.ini
+++ b/device/rg35xx-h/config.ini
@@ -69,8 +69,8 @@ up_threshold=/sys/devices/system/cpu/cpufreq/ondemand/up_threshold
 sampling_down_factor=/sys/devices/system/cpu/cpufreq/ondemand/sampling_down_factor
 io_is_busy=/sys/devices/system/cpu/cpufreq/ondemand/io_is_busy
 sampling_rate_default=200000
-up_threshold_default=78
-sampling_down_factor_default=10
+up_threshold_default=55
+sampling_down_factor_default=5
 io_is_busy_default=1
 
 [network]

--- a/device/rg35xx-plus/config.ini
+++ b/device/rg35xx-plus/config.ini
@@ -69,8 +69,8 @@ up_threshold=/sys/devices/system/cpu/cpufreq/ondemand/up_threshold
 sampling_down_factor=/sys/devices/system/cpu/cpufreq/ondemand/sampling_down_factor
 io_is_busy=/sys/devices/system/cpu/cpufreq/ondemand/io_is_busy
 sampling_rate_default=200000
-up_threshold_default=78
-sampling_down_factor_default=10
+up_threshold_default=55
+sampling_down_factor_default=5
 io_is_busy_default=1
 
 [network]

--- a/device/rg35xx-sp/config.ini
+++ b/device/rg35xx-sp/config.ini
@@ -69,8 +69,8 @@ up_threshold=/sys/devices/system/cpu/cpufreq/ondemand/up_threshold
 sampling_down_factor=/sys/devices/system/cpu/cpufreq/ondemand/sampling_down_factor
 io_is_busy=/sys/devices/system/cpu/cpufreq/ondemand/io_is_busy
 sampling_rate_default=200000
-up_threshold_default=78
-sampling_down_factor_default=10
+up_threshold_default=55
+sampling_down_factor_default=5
 io_is_busy_default=1
 
 [network]


### PR DESCRIPTION
After testing with bgelmini these are the values we've settled on

There current release zip for baked beans is missing /internal/script/var/device/cpu.sh updates. Made an archive to fix.

[GovernorFix.zip](https://github.com/user-attachments/files/16061851/GovernorFix.zip)