### PR TITLE
Add other PC Engine core to assign

### DIFF
--- a/init/MUOS/info/assign/NEC PC Engine.ini
+++ b/init/MUOS/info/assign/NEC PC Engine.ini
@@ -6,3 +6,6 @@ cache=0
 
 [Beetle PCE Fast]
 core=mednafen_pce_fast_libretro.so
+
+[Mednafen PCE]
+core=pce_libretro.so


### PR DESCRIPTION
It's already shipped with muOS just not in assign, works better in some cases since it's a little more accurate than Beetle PCE FAST