### PR TITLE
Create mising info/catalogue/Folder structure.

### DIFF
--- a/script/system/catalogue.sh
+++ b/script/system/catalogue.sh
@@ -23,6 +23,11 @@ GEN_ASSIGN_DIR() {
 	mkdir -p "$BASE_DIR/box" "$BASE_DIR/preview" "$BASE_DIR/text"
 }
 
+SYSTEM_ART="$DC_STO_ROM_MOUNT/MUOS/info/catalogue/Folder"
+if [ ! -d "$SYSTEM_ART" ]; then
+	mkdir -p "$SYSTEM_ART/box" "$SYSTEM_ART/preview" "$SYSTEM_ART/text"
+fi
+
 for INI_FILE in $ASSIGN_DIR; do
 	GEN_ASSIGN_DIR "$INI_FILE"
 done

--- a/script/system/catalogue.sh
+++ b/script/system/catalogue.sh
@@ -24,9 +24,14 @@ GEN_ASSIGN_DIR() {
 }
 
 SYSTEM_ART="$DC_STO_ROM_MOUNT/MUOS/info/catalogue/Folder"
+ROOT_ART="$DC_STO_ROM_MOUNT/MUOS/info/catalogue/Root"
 if [ ! -d "$SYSTEM_ART" ]; then
 	mkdir -p "$SYSTEM_ART/box" "$SYSTEM_ART/preview" "$SYSTEM_ART/text"
 fi
+if [ ! -d "$ROOT_ART" ]; then
+	mkdir -p "$ROOT_ART/box" "$ROOT_ART/preview" "$ROOT_ART/text"
+fi
+
 
 for INI_FILE in $ASSIGN_DIR; do
 	GEN_ASSIGN_DIR "$INI_FILE"


### PR DESCRIPTION
Previously I'd forgotten to add the system artwork /info/catalogue/Folder and subfolders in the auto-creation script.
This has been corrected.