### PR TITLE
Add a DSP filter for the RG35XX H

### DIFF
--- a/init/MUOS/retroarch/filters/audio/RG35XX H.dsp
+++ b/init/MUOS/retroarch/filters/audio/RG35XX H.dsp
@@ -5,11 +5,11 @@ filter2 = crystalizer
 
 # Defaults.
 iir_frequency = 250
-iir_quality = 6.0
+iir_quality = 4.0
 iir_gain = 0.0
 iir_type = HPF
 
 eq_frequencies = "250 400 1000 2500 4200 5200"
-eq_gains = "9 9 -9 15 6 12"
+eq_gains = "10 7 -9 8 0 8"
 
 crystalizer_intensity = 5.0

--- a/init/MUOS/retroarch/filters/audio/RG35XX H.dsp
+++ b/init/MUOS/retroarch/filters/audio/RG35XX H.dsp
@@ -10,6 +10,6 @@ iir_gain = 0.0
 iir_type = HPF
 
 eq_frequencies = "250 400 1000 2500 4200 5200"
-eq_gains = "10 7 -9 8 0 8"
+eq_gains = "7 4 -6 5 -3 5"
 
 crystalizer_intensity = 5.0

--- a/init/MUOS/retroarch/filters/audio/RG35XX H.dsp
+++ b/init/MUOS/retroarch/filters/audio/RG35XX H.dsp
@@ -1,0 +1,15 @@
+filters = 2
+filter0 = iir
+filter1 = eq
+filter2 = crystalizer
+
+# Defaults.
+iir_frequency = 250
+iir_quality = 6.0
+iir_gain = 0.0
+iir_type = HPF
+
+eq_frequencies = "250 400 1000 2500 4200 5200"
+eq_gains = "9 9 -9 15 6 12"
+
+crystalizer_intensity = 5.0


### PR DESCRIPTION
This DSP preset makes the RG35XX H significantly louder and clearer. Users can go to settings => audio => DSP plugin to pick this plugin and improve their sound. It shouldn't be enabled by default only because it will also mess up headphone audio and may eat some CPU.

EQ notes:
> Resonant IIR high pass at 250hz cuts out frequencies below the speaker response, improving amplitude while adding a bass resonance that improves the bass balance somewhat.
> 
> EQ mostly designed to cut a major peak around 1000hz (from 400hz to 2.5khz) to reduce "canny" sound. EQ also boosts volume by about 6dB overall.
> 
> Crystalizer (exciter) tacked onto end to make up for muddiness of speakers (due in part to downward rather than forward facing position).