### PR TITLE
Decompress zipped ROMs for external Mupen64Plus emulator

### DIFF
--- a/script/launch/ext-mupen64plus.sh
+++ b/script/launch/ext-mupen64plus.sh
@@ -44,7 +44,25 @@ fi
 chmod +x "$EMUDIR"/mupen64plus
 cd "$EMUDIR" || exit
 
+# Decompress zipped ROMs since the emulator doesn't natively support them.
+case "$ROM" in *.zip)
+	TMPDIR="$(mktemp -d)"
+	unzip -q "$ROM" -d "$TMPDIR"
+	# Pick first file with a supported extension.
+	for TMPFILE in "$TMPDIR"/*; do
+		case "$TMPFILE" in *.n64|*.v64|*.z64)
+			ROM="$TMPFILE"
+			break
+		;; esac
+	done
+;; esac
+
 HOME="$EMUDIR" SDL_ASSERT=always_ignore ./mupen64plus --corelib ./libmupen64plus.so.2.0.0 --configdir . "$ROM"
+
+# Clean up temp files if we unzipped the ROM.
+if [ -n "$TMPDIR" ]; then
+	rm -r "$TMPDIR"
+fi
 
 case "$DC_DEV_NAME" in
 	RG*)


### PR DESCRIPTION
See [this Discord message](https://discord.com/channels/1152022492001603615/1265448287767498752/1265448287767498752) for additional context. Credit goes to VooD on the muOS Discord for the idea and initial changes. 😃

The Mupen64Plus emulator (external version, not the RetroArch core) doesn't support zipped ROMs. For consistency with RetroArch and other external emulators like Drastic, it'd be nice to support them. And it's easy enough to decompress the ROM in the launch script.

This PR only supports zip, not 7z or other formats. That's probably fine, but we could support others easily enough if we have the relevant decompressor binaries.