### PR TITLE
Remove LOAD_STATE from RA resume (we no longer SAVE_STATE on sleep)

### DIFF
--- a/script/launch/lr-easyrpg.sh
+++ b/script/launch/lr-easyrpg.sh
@@ -39,13 +39,4 @@ else
 	RA_PID=$!
 fi
 
-# We have to pause just for a moment to let RetroArch finish loading...
-sleep 5
-
-if [ "$GC_GEN_STARTUP" = last ] || [ "$GC_GEN_STARTUP" = resume ]; then
-	if [ ! -e "/tmp/manual_launch" ]; then
-		retroarch --command LOAD_STATE
-	fi
-fi
-
 wait $RA_PID

--- a/script/launch/lr-general.sh
+++ b/script/launch/lr-general.sh
@@ -36,13 +36,4 @@ echo "retroarch" >/tmp/fg_proc
 retroarch -v -f -c "$DC_STO_ROM_MOUNT/MUOS/retroarch/retroarch.cfg" -L "$DC_STO_ROM_MOUNT/MUOS/core/$CORE" "$ROM" &
 RA_PID=$!
 
-# We have to pause just for a moment to let RetroArch finish loading...
-sleep 5
-
-if [ "$GC_GEN_STARTUP" = last ] || [ "$GC_GEN_STARTUP" = resume ]; then
-	if [ ! -e "/tmp/manual_launch" ]; then
-		retroarch --command LOAD_STATE
-	fi
-fi
-
 wait $RA_PID

--- a/script/launch/lr-nxengine.sh
+++ b/script/launch/lr-nxengine.sh
@@ -85,13 +85,4 @@ else
 	RA_PID=$!
 fi
 
-# We have to pause just for a moment to let RetroArch finish loading...
-sleep 5
-
-if [ "$GC_GEN_STARTUP" = last ] || [ "$GC_GEN_STARTUP" = resume ]; then
-	if [ ! -e "/tmp/manual_launch" ]; then
-		retroarch --command LOAD_STATE
-	fi
-fi
-
 wait $RA_PID

--- a/script/launch/lr-prboom.sh
+++ b/script/launch/lr-prboom.sh
@@ -37,13 +37,4 @@ cp -f "$ROMPATH/.IWAD/$IWAD" "$ROMPATH/.$NAME/$IWAD"
 retroarch -v -f -c "$DC_STO_ROM_MOUNT/MUOS/retroarch/retroarch.cfg" -L "$DC_STO_ROM_MOUNT/MUOS/core/prboom_libretro.so" "$ROMPATH/.$NAME/$IWAD" &
 RA_PID=$!
 
-# We have to pause just for a moment to let RetroArch finish loading...
-sleep 5
-
-if [ "$GC_GEN_STARTUP" = last ] || [ "$GC_GEN_STARTUP" = resume ]; then
-	if [ ! -e "/tmp/manual_launch" ]; then
-		retroarch --command LOAD_STATE
-	fi
-fi
-
 wait $RA_PID

--- a/script/launch/lr-scummvm.sh
+++ b/script/launch/lr-scummvm.sh
@@ -34,13 +34,4 @@ cp "$ROMPATH/$NAME.scummvm" "$SCVM"
 retroarch -v -f -c "$DC_STO_ROM_MOUNT/MUOS/retroarch/retroarch.cfg" -L "$DC_STO_ROM_MOUNT/MUOS/core/scummvm_libretro.so" "$SCVM" &
 RA_PID=$!
 
-# We have to pause just for a moment to let RetroArch finish loading...
-sleep 5
-
-if [ "$GC_GEN_STARTUP" = last ] || [ "$GC_GEN_STARTUP" = resume ]; then
-	if [ ! -e "/tmp/manual_launch" ]; then
-		retroarch --command LOAD_STATE
-	fi
-fi
-
 wait $RA_PID


### PR DESCRIPTION
[Related Discord thread w/ more investigation.](https://discord.com/channels/1152022492001603615/1266267984570355712)

Since e14fa39, muOS no longer sends RetroArch a `SAVE_STATE` command on sleep. Instead, it relies on RA's own "Auto Save State" setting, which the user can enable if they want. This resolves some issues (like duplicate save states), but creates a new one. When muOS is set to resume the previous game on boot, it still sends a `LOAD_STATE` command to RA a few seconds after launching the game. This causes two problems:

1. When RA's "Auto Load State" setting is enabled, RA loads the autosave it created on sleep... and then a couple seconds later, muOS loads a different state (the highest numbered one).
2. Since muOS no longer _saves_ a numbered state on sleep, the state it loads is almost certainly not the one the user wants. It's the last manual/numbered state they saved, which may be a lot older than the RA autosave state.

It seems like the intent of the `power.sh` change was to rely solely on RA's own autosave/load support, which the user can enable or disable as they see fit. So removing the `LOAD_STATE` commands from the launch scripts seems necessary to complete the picture.