### PR TITLE
Wait for D-Bus before starting PipeWire

### DIFF
--- a/script/system/pipewire.sh
+++ b/script/system/pipewire.sh
@@ -3,6 +3,20 @@
 . /opt/muos/script/var/func.sh
 . /opt/muos/script/var/device/audio.sh
 
+for TIMEOUT in $(seq 1 30); do
+	if [ -e /run/dbus/system_bus_socket ]; then
+		printf "D-Bus socket is available\n"
+		break
+	fi
+	printf "(%d of 30) Waiting for D-Bus...\n" "$TIMEOUT"
+	sleep 1
+done
+
+if [ ! -e /run/dbus/system_bus_socket ]; then
+	printf "Timeout expired waiting for D-Bus\n"
+	exit 1
+fi
+
 if ! pgrep -x "pipewire" >/dev/null; then
 	pipewire &
 	printf "Starting PipeWire\n"

--- a/script/system/startup.sh
+++ b/script/system/startup.sh
@@ -24,7 +24,7 @@ echo "pipewire" >$AUDIO_SRC
 }
 udevadm trigger --type=subsystems --action=add &
 udevadm trigger --type=devices --action=add &
-# udevadm settle --timeout=30 || echo "udevadm settle failed"
+udevadm settle --timeout=30 || echo "udevadm settle failed"
 
 if [ -s "$GLOBAL_CONFIG" ]; then
 	LOGGER "$0" "BOOTING" "Global Config Check Passed"


### PR DESCRIPTION
[Context on Discord.](https://discord.com/channels/1152022492001603615/1266922760685355150/1267178019999449118)

It appears that the PipeWire and D-Bus daemons race on boot, and if D-Bus doesn't come up fast enough, `pipewire` startup fails (though the `pipewire` binary keeps running):

```
Failed to connect to bus: Could not connect: No such file or directory
M 12:34:09.861922        wireplumber ../src/main.c:364:on_disconnected: disconnected from pipewire
```

This leaves the system in a start where RetroArch fails hangs while initializing audio, as the PipeWire shared libs it links wait forever while trying to talk to the `pipewire` daemon.

Waiting for D-Bus to be available before starting PipeWire seems to fix this issue for me. (Not sure if there's a better way to wait for D-Bus than just polling for the socket to exist....)