### PR TITLE
Safe Shutdown: Add script for cleaner shutdown (kill procs, unmount filesystems) and use it on sleep timeout

### DIFF
--- a/device/rg28xx/input/trigger/sleep.sh
+++ b/device/rg28xx/input/trigger/sleep.sh
@@ -7,7 +7,6 @@
 SLEEP_STATE="/tmp/sleep_state"
 SLEEP_TIMER="/tmp/sleep_timer"
 LOG_FILE="/tmp/mushutdown_log.txt"
-MUSHUTDOWN_CMD="/opt/muos/bin/mushutdown"
 
 echo "0" >"$SLEEP_TIMER"
 
@@ -31,7 +30,7 @@ while true; do
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			echo "" >/opt/muos/config/lastplay.txt
 		fi
-		$MUSHUTDOWN_CMD >>"$LOG_FILE" 2>&1
+		/opt/muos/script/system/halt.sh poweroff >>"$LOG_FILE" 2>&1
 		if [ $? -ne 0 ]; then
 			echo "Shutdown failed at $(date)" >>"$LOG_FILE"
 		fi

--- a/device/rg35xx-2024/input/trigger/sleep.sh
+++ b/device/rg35xx-2024/input/trigger/sleep.sh
@@ -7,7 +7,6 @@
 SLEEP_STATE="/tmp/sleep_state"
 SLEEP_TIMER="/tmp/sleep_timer"
 LOG_FILE="/tmp/mushutdown_log.txt"
-MUSHUTDOWN_CMD="/opt/muos/bin/mushutdown"
 
 echo "0" >"$SLEEP_TIMER"
 
@@ -31,7 +30,7 @@ while true; do
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			echo "" >/opt/muos/config/lastplay.txt
 		fi
-		$MUSHUTDOWN_CMD >>"$LOG_FILE" 2>&1
+		/opt/muos/script/system/halt.sh poweroff >>"$LOG_FILE" 2>&1
 		if [ $? -ne 0 ]; then
 			echo "Shutdown failed at $(date)" >>"$LOG_FILE"
 		fi

--- a/device/rg35xx-h/input/trigger/sleep.sh
+++ b/device/rg35xx-h/input/trigger/sleep.sh
@@ -7,7 +7,6 @@
 SLEEP_STATE="/tmp/sleep_state"
 SLEEP_TIMER="/tmp/sleep_timer"
 LOG_FILE="/tmp/mushutdown_log.txt"
-MUSHUTDOWN_CMD="/opt/muos/bin/mushutdown"
 
 echo "0" >"$SLEEP_TIMER"
 
@@ -31,7 +30,7 @@ while true; do
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			echo "" >/opt/muos/config/lastplay.txt
 		fi
-		$MUSHUTDOWN_CMD >>"$LOG_FILE" 2>&1
+		/opt/muos/script/system/halt.sh poweroff >>"$LOG_FILE" 2>&1
 		if [ $? -ne 0 ]; then
 			echo "Shutdown failed at $(date)" >>"$LOG_FILE"
 		fi

--- a/device/rg35xx-plus/input/trigger/sleep.sh
+++ b/device/rg35xx-plus/input/trigger/sleep.sh
@@ -7,7 +7,6 @@
 SLEEP_STATE="/tmp/sleep_state"
 SLEEP_TIMER="/tmp/sleep_timer"
 LOG_FILE="/tmp/mushutdown_log.txt"
-MUSHUTDOWN_CMD="/opt/muos/bin/mushutdown"
 
 echo "0" >"$SLEEP_TIMER"
 
@@ -31,7 +30,7 @@ while true; do
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			echo "" >/opt/muos/config/lastplay.txt
 		fi
-		$MUSHUTDOWN_CMD >>"$LOG_FILE" 2>&1
+		/opt/muos/script/system/halt.sh poweroff >>"$LOG_FILE" 2>&1
 		if [ $? -ne 0 ]; then
 			echo "Shutdown failed at $(date)" >>"$LOG_FILE"
 		fi

--- a/device/rg35xx-sp/input/trigger/sleep.sh
+++ b/device/rg35xx-sp/input/trigger/sleep.sh
@@ -7,7 +7,6 @@
 SLEEP_STATE="/tmp/sleep_state"
 SLEEP_TIMER="/tmp/sleep_timer"
 LOG_FILE="/tmp/mushutdown_log.txt"
-MUSHUTDOWN_CMD="/opt/muos/bin/mushutdown"
 
 echo "0" >"$SLEEP_TIMER"
 
@@ -31,7 +30,7 @@ while true; do
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			echo "" >/opt/muos/config/lastplay.txt
 		fi
-		$MUSHUTDOWN_CMD >>"$LOG_FILE" 2>&1
+		/opt/muos/script/system/halt.sh poweroff >>"$LOG_FILE" 2>&1
 		if [ $? -ne 0 ]; then
 			echo "Shutdown failed at $(date)" >>"$LOG_FILE"
 		fi

--- a/device/rg35xx-sp/script/start.sh
+++ b/device/rg35xx-sp/script/start.sh
@@ -14,7 +14,7 @@
 HALL_KEY="/sys/class/power_supply/axp2202-battery/hallkey"
 
 if [ "$(cat "$HALL_KEY")" = "0" ] && [ "$(cat "$DC_BAT_CHARGER")" -eq 0 ]; then
-	/opt/muos/bin/mushutdown
+	/opt/muos/script/system/halt.sh poweroff
 fi
 
 sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.conf

--- a/device/rg40xx/input/trigger/sleep.sh
+++ b/device/rg40xx/input/trigger/sleep.sh
@@ -7,7 +7,6 @@
 SLEEP_STATE="/tmp/sleep_state"
 SLEEP_TIMER="/tmp/sleep_timer"
 LOG_FILE="/tmp/mushutdown_log.txt"
-MUSHUTDOWN_CMD="/opt/muos/bin/mushutdown"
 
 echo "0" >"$SLEEP_TIMER"
 
@@ -31,7 +30,7 @@ while true; do
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			echo "" >/opt/muos/config/lastplay.txt
 		fi
-		$MUSHUTDOWN_CMD >>"$LOG_FILE" 2>&1
+		/opt/muos/script/system/halt.sh poweroff >>"$LOG_FILE" 2>&1
 		if [ $? -ne 0 ]; then
 			echo "Shutdown failed at $(date)" >>"$LOG_FILE"
 		fi

--- a/init/MUOS/application/Safe Reboot.sh
+++ b/init/MUOS/application/Safe Reboot.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+. /opt/muos/script/var/global/setting_general.sh
+
+# Clear saved IP address and last played game. (See
+# https://github.com/MustardOS/frontend/blob/main/muxlaunch/main.c.)
+: >/opt/muos/config/address.txt
+if [ "$GC_GEN_STARTUP" = resume ]; then
+	: >/opt/muos/config/lastplay.txt
+fi
+
+/opt/muos/bin/fbpad /opt/muos/script/system/halt.sh reboot

--- a/init/MUOS/application/Safe Shutdown.sh
+++ b/init/MUOS/application/Safe Shutdown.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+. /opt/muos/script/var/global/setting_general.sh
+
+# Clear saved IP address and last played game. (See
+# https://github.com/MustardOS/frontend/blob/main/muxlaunch/main.c.)
+: >/opt/muos/config/address.txt
+if [ "$GC_GEN_STARTUP" = resume ]; then
+	: >/opt/muos/config/lastplay.txt
+fi
+
+/opt/muos/bin/fbpad /opt/muos/script/system/halt.sh poweroff

--- a/script/system/halt.sh
+++ b/script/system/halt.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+case "$1" in
+	halt|poweroff|reboot)
+		HALT_CMD="$1"
+		;;
+	*)
+		printf 'Usage: %s {halt|poweroff|reboot}\n' "$0" >&2
+		exit 1
+		;;
+esac
+
+# As a debugging aid, check if our parent process is fbpad so we can avoid
+# killing it. This gives us an easy way to see full script output up to the
+# final halt command.
+if [ "$(readlink "/proc/$PPID/exe")" = /opt/muos/bin/fbpad ]; then
+	OMIT_PID="$PPID"
+else
+	OMIT_PID=
+fi
+
+# Our shutdown sequence kills processes using killall5, which sends signals to
+# every process except those in the current session. This means by default, we
+# might miss killing some processes (e.g., background jobs in the same shell as
+# halt.sh is invoked.)
+#
+# We address this by wrapping the actual shutdown sequence in a setsid command,
+# ensuring we invoke killall5 from a new (and otherwise empty) session.
+#
+# Use -f to always fork a new process, even if it would possible for the
+# current process to become a session leader directly. This ensures
+# halt_internal.sh always gets a new PID, which prevents our parent process
+# from "helpfully" trying to kill us when it terminates.
+#
+# Use -w to wait for halt_internal.sh to terminate. On a successful halt, that
+# doesn't really matter, but it allows us to return an appropriate exit status
+# if the shutdown fails partway through.
+exec setsid -fw /opt/muos/script/system/halt_internal.sh "$HALT_CMD" "$OMIT_PID"

--- a/script/system/halt_internal.sh
+++ b/script/system/halt_internal.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+# Wraps killall5 and automatically omits the specified PID (if any).
+KILL_PROCS () {
+	if [ -n "$OMIT_PID" ]; then
+		killall5 "$@" -o "$OMIT_PID"
+	else
+		killall5 "$@"
+	fi
+}
+
+# Waits 5 seconds for processes we SIGTERM'd to die. The `killall5 -CONT` trick
+# is inspired by various old sysvinit scripts as a harmless way to check if any
+# processes we targeted with SIGTERM are still alive.
+WAIT_FOR_DEATH () {
+	printf 'Waiting for processes to terminate: '
+	for _ in $(seq 5); do
+		sleep 1
+		# If killall5 didn't find any processes to signal, they must
+		# all have terminated already, and we can stop waiting.
+		if ! KILL_PROCS -CONT; then
+			printf 'done\n'
+			return
+		fi
+	done
+	# After waiting politely a few seconds, let SIGKILL take care of 'em.
+	printf 'timed out\n'
+}
+
+# Sanity check parameters.
+if [ "$#" -ne 2 ]; then
+	printf 'Wrong number of arguments (run halt.sh, not halt_internal.sh)\n' >&2
+	exit 1
+fi
+
+HALT_CMD="$1"
+OMIT_PID="$2"
+
+# Sanity check that SID = PID. (See note on setsid in halt.sh for rationale.)
+if [ "$(cut -d ' ' -f 6 /proc/self/stat)" -ne "$$" ]; then
+	printf 'Not a session leader (run halt.sh, not halt_internal.sh)\n' >&2
+	exit 1
+fi
+
+# Stop system services.
+printf 'Stopping init scripts...\n'
+/etc/init.d/rcK
+
+# Terminate other processes before halting. This is essentially what init
+# should do for us, but for some reason, BusyBox shutdown often hangs. This
+# doesn't seem to. (Why? Not sure, but it may be because we wait for processes
+# to terminate, and don't unmount till they're gone.)
+printf 'Sending SIGTERM to processes...\n'
+KILL_PROCS -TERM
+WAIT_FOR_DEATH
+
+printf 'Sending SIGKILL to processes...\n'
+KILL_PROCS -KILL
+
+# Disable swap (we don't actually have any, but it's standard in shutdown
+# sequences) and cleanly unmount filesystems to avoid fsck/chkdsk errors.
+printf 'Disabling swap...\n'
+swapoff -a
+
+printf 'Unmounting filesystems...\n'
+umount -ar
+
+# Actually halt/shut down/reboot the system. Note the -f so the halt command
+# only calls sync and reboot under the hood, rather than signaling init to
+# start its own buggy shutdown sequence.
+printf 'Going down for %s...\n' "$HALT_CMD"
+"$HALT_CMD" -f


### PR DESCRIPTION
**Note**: I'm sending this PR for early thoughts and additional testing. It's a solution to a problem that may primarily just bother me, and it won't hurt my feelings if you end up not wanting to merge this. (Of course, even if it does get merged, it still needs than my limited testing so far.)

**TL;DR**: I was bothered by the lack of clean SD card unmounting on shutdown/reboot. Went down a few rabbit holes and ended up with a new shutdown script that I've been using for a few days. Would much appreciate any feedback on the idea/implementation. Thanks!!

### Background

Currently, muOS shuts down (or reboots) by calling the `sync` and `reboot` syscalls in order, without terminating running processing or unmounting filesystems. The `sync` mitigates most of the risk of data loss due to write caching, but there's a couple of issues with the current approach:

1. The `sync` and `reboot` syscalls aren't one atomic operation. Processes can still be writing files in the middle of this operation, and those writes will be lost. Additionally, since FAT32/exFAT aren't journaled, this can affect FS metadata, not just contents.
2. Because the filesystems aren't unmounted cleanly, `fsck` (on Linux) or `chkdsk` (on Windows) will want to scan/fix the SD cards. Indeed, every time I shut down muOS from the UI and plug the SD card into my PC, Windows complains it wasn't cleanly removed, and `chkdsk` even finds lost clusters on occasion (actual FS corruption, though not in any important files so far).

I wondered why muOS didn't just use BusyBox's builtin `shutdown` and `reboot` commands. After some testing, I think I got my answer: They often hang (like `halt` would) instead of actually powering off. (It's not obvious on shutdown since there's no visual indication this happened, but one test I found is to press the reset button after shutting down. If the device is really off, nothing happens. If it's stuck on, then the muOS boot sequence will begin.)

I briefly tried debugging exactly where the BusyBox shutdown sequence gets stuck, but it's really tricky without a serial console, and I don't want to open up my device to get to the UART port just yet. Additionally, the BusyBox shutdown makes some (IMO) questionable choices like unmounting file systems _before_ terminating running processes.

### Proposed changes

I decided the "proper muOS" approach was to write my own minimal version of a standard Linux shutdown sequence (stop system services, SIGTERM/KILL processes, unmount disks, power off/reboot) as a shell script. :)

The interesting bits are in `halt.sh` and `halt_internal.sh`, which actually implement the shutdown. These look kind of like the shutdown scripts on simpler/older Linux distros. (If you've seen the pre-systemd Arch Linux shutdown, it's conceptually similar, though this one is implemented from scratch and doesn't reuse code from any specific distro.)

### Testing so far

I tested the scripts from the muOS terminal and over SSH, and I also updated `sleep.sh` to use this instead of `mushutdown`. (I have sleep set to "instant shutdown", but it should work the same with the timeout.)

For debugging, I also added two scripts to the `application` directory: "Safe Shutdown" and "Safe Reboot". These run give a quick way to run the new flow from the launcher. Since I haven't updated `muxlaunch`'s built-in shutdown/reboot actions yet, I've been using these temporary applications for all my non-power-button shutdowns.

The debug apps run the shutdown/reboot flow in `fbpad`. `halt.sh` checks for this and specifically avoids killing `fbterm`, so you can actually see the full scriptoutput up to the final `poweroff -f` or `shutdown -f` command. (For testing, it was handy to see the output from `umount` and such to know if anything was going wrong.)

If you want to test this yourself, you should probably grab the `/etc/init.d` changes from https://github.com/MustardOS/rootfs/pull/4 too.

### Not done yet

* Testing with devices other than the RG35XX-H. (I don't have access to others.)
* More testing in general. (I've used this script in various forms for a few days of normal gameplay. I can confirm it fixes my disk errors when mounting the SD card on PC. So far, I haven't noticed any hangs, but it's hard to prove a negative....)
* Changing the frontend repo to replace `reboot` syscalls with invocations of `halt.sh`. (So far, I've just been using the "Safe Shutdown" script instead of the launcher's shutdown)
* Considering if there's a way to get the BusyBox shutdown working properly after all.