### PR TITLE
Guard verbose shutdown output by advanced setting

### DIFF
--- a/script/mux/frontend.sh
+++ b/script/mux/frontend.sh
@@ -34,12 +34,17 @@ KILL_BGM() {
 }
 
 PREPARE_HALT() {
+	. /opt/muos/script/var/global/setting_advanced.sh
 	. /opt/muos/script/var/global/setting_general.sh
 	: >/opt/muos/config/address.txt
 	if [ "$GC_GEN_STARTUP" = resume ]; then
 		: >/opt/muos/config/lastplay.txt
 	fi
-	/opt/muos/bin/fbpad /opt/muos/script/system/halt.sh "$1"
+	if [ "$GC_ADV_VERBOSE" -eq 1 ]; then
+		/opt/muos/bin/fbpad /opt/muos/script/system/halt.sh "$1"
+	else
+		/opt/muos/script/system/halt.sh "$1"
+	fi
 }
 
 LOGGER "$0" "FRONTEND" "Waiting for mount: $DC_STO_ROM_MOUNT"


### PR DESCRIPTION
Right now there's no way to _set_ the pref in the UI, only the config file. I'll look at that tomorrow. But this is a quick change to hide the verbose output by default.