### PR TITLE
Sync themes from SD1 to Prefered Storage after install.

### DIFF
--- a/script/mux/extract.sh
+++ b/script/mux/extract.sh
@@ -66,6 +66,8 @@ fi
 echo "Sync Filesystem"
 sync
 
+/opt/muos/script/mux/sync_storage.sh &
+
 echo "All Done!"
 touch "$DC_STO_ROM_MOUNT/MUOS/update/installed/$ARCHIVE_NAME.done"
 sleep 2

--- a/script/mux/sync_storage.sh
+++ b/script/mux/sync_storage.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Import muOS Functions
+. /opt/muos/script/var/func.sh
+
+. /opt/muos/script/var/device/storage.sh
+
+. /opt/muos/script/var/global/storage.sh
+
+if [ ! $GC_STO_THEME = "$DC_STO_ROM_MOUNT" ]; then
+    if [ ! -d "$GC_STO_THEME/MUOS/theme/" ]; then
+        mkdir -p "$GC_STO_THEME/MUOS/theme/"
+    fi
+    rsync -a "$DC_STO_ROM_MOUNT/MUOS/theme/" "$GC_STO_THEME/MUOS/theme/"
+fi


### PR DESCRIPTION
This allows themes to be stored on SD2/USB etc but still install as normal via Archive Manager.
Requires rsync (coming soon)