### PR TITLE
Fix "sleep suspend" going back to sleep immediately when device is woken up via long press of power button

### DIFF
--- a/device/rg28xx/input/input.sh
+++ b/device/rg28xx/input/input.sh
@@ -16,6 +16,7 @@ killall -q "evtest"
 . /opt/muos/device/"$DEVICE_TYPE"/input/map.sh
 
 KEY_COMBO=0
+RESUME_UPTIME="$(UPTIME)"
 
 DPAD="/sys/class/power_supply/axp2202-battery/nds_pwrkey"
 MOTO="/sys/class/power_supply/axp2202-battery/moto"
@@ -93,7 +94,16 @@ fi
 
 		COUNT_POWER_LONG=0
 		if [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			/opt/muos/script/system/suspend.sh power
+			# When the user presses power to wake from suspend, the
+			# press/release events are received by our evtest loop
+			# after wakeup. A long press sends us right back here.
+			#
+			# Avoid suspending again immediately by ignoring power
+			# long presses processed within 100ms of wakeup.
+			if [ "$(echo "$(UPTIME) - $RESUME_UPTIME >= .1" | bc)" = 1 ]; then
+				/opt/muos/script/system/suspend.sh power
+				RESUME_UPTIME="$(UPTIME)"
+			fi
 		else
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then

--- a/device/rg35xx-h/input/input.sh
+++ b/device/rg35xx-h/input/input.sh
@@ -15,6 +15,7 @@ killall -q "evtest"
 . /opt/muos/device/"$DEVICE_TYPE"/input/map.sh
 
 KEY_COMBO=0
+RESUME_UPTIME="$(UPTIME)"
 
 # Place combo and trigger scripts here because fuck knows why for loops won't work...
 # Make sure to put them in order of how you want them to work too!
@@ -81,7 +82,16 @@ fi
 
 		COUNT_POWER_LONG=0
 		if [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			/opt/muos/script/system/suspend.sh power
+			# When the user presses power to wake from suspend, the
+			# press/release events are received by our evtest loop
+			# after wakeup. A long press sends us right back here.
+			#
+			# Avoid suspending again immediately by ignoring power
+			# long presses processed within 100ms of wakeup.
+			if [ "$(echo "$(UPTIME) - $RESUME_UPTIME >= .1" | bc)" = 1 ]; then
+				/opt/muos/script/system/suspend.sh power
+				RESUME_UPTIME="$(UPTIME)"
+			fi
 		else
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then

--- a/device/rg35xx-sp/input/input.sh
+++ b/device/rg35xx-sp/input/input.sh
@@ -15,6 +15,7 @@ killall -q "evtest"
 . /opt/muos/device/"$DEVICE_TYPE"/input/map.sh
 
 KEY_COMBO=0
+RESUME_UPTIME="$(UPTIME)"
 
 HALL="/sys/class/power_supply/axp2202-battery/hallkey"
 DPAD="/sys/class/power_supply/axp2202-battery/nds_pwrkey"
@@ -93,7 +94,16 @@ fi
 
 		COUNT_POWER_LONG=0
 		if [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			/opt/muos/script/system/suspend.sh power
+			# When the user presses power to wake from suspend, the
+			# press/release events are received by our evtest loop
+			# after wakeup. A long press sends us right back here.
+			#
+			# Avoid suspending again immediately by ignoring power
+			# long presses processed within 100ms of wakeup.
+			if [ "$(echo "$(UPTIME) - $RESUME_UPTIME >= .1" | bc)" = 1 ]; then
+				/opt/muos/script/system/suspend.sh power
+				RESUME_UPTIME="$(UPTIME)"
+			fi
 		else
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then

--- a/device/rg40xx/input/input.sh
+++ b/device/rg40xx/input/input.sh
@@ -16,6 +16,7 @@ killall -q "evtest"
 . /opt/muos/device/"$DEVICE_TYPE"/input/map.sh
 
 KEY_COMBO=0
+RESUME_UPTIME="$(UPTIME)"
 
 # Place combo and trigger scripts here because fuck knows why for loops won't work...
 # Make sure to put them in order of how you want them to work too!
@@ -82,7 +83,16 @@ fi
 
 		COUNT_POWER_LONG=0
 		if [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			/opt/muos/script/system/suspend.sh power
+			# When the user presses power to wake from suspend, the
+			# press/release events are received by our evtest loop
+			# after wakeup. A long press sends us right back here.
+			#
+			# Avoid suspending again immediately by ignoring power
+			# long presses processed within 100ms of wakeup.
+			if [ "$(echo "$(UPTIME) - $RESUME_UPTIME >= .1" | bc)" = 1 ]; then
+				/opt/muos/script/system/suspend.sh power
+				RESUME_UPTIME="$(UPTIME)"
+			fi
 		else
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then

--- a/script/var/func.sh
+++ b/script/var/func.sh
@@ -44,6 +44,13 @@ FB_SWITCH() {
 	echo 0 >/sys/class/graphics/fb0/blank
 }
 
+# Prints current system uptime in hundredths of a second. Unlike date or
+# EPOCHREALTIME, this won't decrease if the system clock is set back, so it can
+# be used to measure an interval of real time.
+UPTIME () {
+	cut -d ' ' -f 1 /proc/uptime
+}
+
 PARSE_INI() {
 	INI_FILE="$1"
 	SECTION="$2"


### PR DESCRIPTION
[Video](https://discord.com/channels/1152022492001603615/1192322914431815742/1269354868569538600) and [debug analysis](https://discord.com/channels/1152022492001603615/1192322914431815742/1269341407999692840) of the problem on Discord.

This _only_ affects the new "sleep suspend" mode where we suspend to RAM on long press of power. "Instant shutdown" and "sleep XXs + suspend" modes are unaffected.

I don't love timing-based fixes like this one, but in practice, this seems to work fine. With this patched in, I can't get the device to accidentally go back to suspend no matter how long I hold power on wake, and it's hard to press/release power fast enough to intentionally get a _wanted_ suspend event to be missed.