### PR TITLE
Resume before closing RetroArch on sleep timeout (fixes hang that breaks "auto save state" RA setting)

### DIFF
--- a/device/rg28xx/input/trigger/sleep.sh
+++ b/device/rg28xx/input/trigger/sleep.sh
@@ -24,6 +24,7 @@ while true; do
 	fi
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
+		/opt/muos/script/system/suspend.sh resume
 		CLOSE_CONTENT
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			: >/opt/muos/config/lastplay.txt

--- a/device/rg35xx-2024/input/trigger/sleep.sh
+++ b/device/rg35xx-2024/input/trigger/sleep.sh
@@ -24,6 +24,7 @@ while true; do
 	fi
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
+		/opt/muos/script/system/suspend.sh resume
 		CLOSE_CONTENT
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			: >/opt/muos/config/lastplay.txt

--- a/device/rg35xx-h/input/trigger/sleep.sh
+++ b/device/rg35xx-h/input/trigger/sleep.sh
@@ -24,6 +24,7 @@ while true; do
 	fi
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
+		/opt/muos/script/system/suspend.sh resume
 		CLOSE_CONTENT
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			: >/opt/muos/config/lastplay.txt

--- a/device/rg35xx-plus/input/trigger/sleep.sh
+++ b/device/rg35xx-plus/input/trigger/sleep.sh
@@ -24,6 +24,7 @@ while true; do
 	fi
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
+		/opt/muos/script/system/suspend.sh resume
 		CLOSE_CONTENT
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			: >/opt/muos/config/lastplay.txt

--- a/device/rg35xx-sp/input/trigger/sleep.sh
+++ b/device/rg35xx-sp/input/trigger/sleep.sh
@@ -24,6 +24,7 @@ while true; do
 	fi
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
+		/opt/muos/script/system/suspend.sh resume
 		CLOSE_CONTENT
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			: >/opt/muos/config/lastplay.txt

--- a/device/rg40xx/input/trigger/sleep.sh
+++ b/device/rg40xx/input/trigger/sleep.sh
@@ -24,6 +24,7 @@ while true; do
 	fi
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
+		/opt/muos/script/system/suspend.sh resume
 		CLOSE_CONTENT
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			: >/opt/muos/config/lastplay.txt


### PR DESCRIPTION
[Discord thread w/ context](https://discord.com/channels/1152022492001603615/1269421080460918784)

Turns out while `pipewire` is `SIGSTOP`'d, RetroArch just hangs forever. It doesn't respond to `SIGTERM`, it doesn't exit cleanly, and it doesn't write its autosave.

It looks like we might be able to get by with just `pkill -CONT pipewire` here, but it's not noticeably slower to do the full resume. (And reenabling the sleeping CPU cores might actually make shutdown _faster_.)

Unfortunately, this does reintroduce the momentary blip of game audio between the `SIGCONT` of RetroArch and when it actually exits. Probably we should find some way to mute that (but also, previous releases had the same issue).