### PR TITLE
Fix RetroArch hangs and unnecessarily long delays when closing content on sleep timeout

### DIFF
--- a/device/rg28xx/input/trigger/sleep.sh
+++ b/device/rg28xx/input/trigger/sleep.sh
@@ -25,11 +25,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		CLOSE_CONTENT
-		if [ "$FG_PROC_VAL" != "retroarch" ]; then
-			: >/opt/muos/config/lastplay.txt
-		fi
-		/opt/muos/script/system/halt.sh poweroff
+		CLOSE_CONTENT_AND_HALT poweroff
 	fi
 
 	sleep 1

--- a/device/rg28xx/input/trigger/sleep.sh
+++ b/device/rg28xx/input/trigger/sleep.sh
@@ -24,6 +24,7 @@ while true; do
 	fi
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
+		/opt/muos/script/system/suspend.sh resume
 		CLOSE_CONTENT
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			: >/opt/muos/config/lastplay.txt

--- a/device/rg35xx-2024/input/trigger/sleep.sh
+++ b/device/rg35xx-2024/input/trigger/sleep.sh
@@ -25,11 +25,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		CLOSE_CONTENT
-		if [ "$FG_PROC_VAL" != "retroarch" ]; then
-			: >/opt/muos/config/lastplay.txt
-		fi
-		/opt/muos/script/system/halt.sh poweroff
+		CLOSE_CONTENT_AND_HALT poweroff
 	fi
 
 	sleep 1

--- a/device/rg35xx-2024/input/trigger/sleep.sh
+++ b/device/rg35xx-2024/input/trigger/sleep.sh
@@ -24,6 +24,7 @@ while true; do
 	fi
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
+		/opt/muos/script/system/suspend.sh resume
 		CLOSE_CONTENT
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			: >/opt/muos/config/lastplay.txt

--- a/device/rg35xx-h/input/trigger/sleep.sh
+++ b/device/rg35xx-h/input/trigger/sleep.sh
@@ -25,11 +25,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		CLOSE_CONTENT
-		if [ "$FG_PROC_VAL" != "retroarch" ]; then
-			: >/opt/muos/config/lastplay.txt
-		fi
-		/opt/muos/script/system/halt.sh poweroff
+		CLOSE_CONTENT_AND_HALT poweroff
 	fi
 
 	sleep 1

--- a/device/rg35xx-h/input/trigger/sleep.sh
+++ b/device/rg35xx-h/input/trigger/sleep.sh
@@ -24,6 +24,7 @@ while true; do
 	fi
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
+		/opt/muos/script/system/suspend.sh resume
 		CLOSE_CONTENT
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			: >/opt/muos/config/lastplay.txt

--- a/device/rg35xx-plus/input/trigger/sleep.sh
+++ b/device/rg35xx-plus/input/trigger/sleep.sh
@@ -25,11 +25,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		CLOSE_CONTENT
-		if [ "$FG_PROC_VAL" != "retroarch" ]; then
-			: >/opt/muos/config/lastplay.txt
-		fi
-		/opt/muos/script/system/halt.sh poweroff
+		CLOSE_CONTENT_AND_HALT poweroff
 	fi
 
 	sleep 1

--- a/device/rg35xx-plus/input/trigger/sleep.sh
+++ b/device/rg35xx-plus/input/trigger/sleep.sh
@@ -24,6 +24,7 @@ while true; do
 	fi
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
+		/opt/muos/script/system/suspend.sh resume
 		CLOSE_CONTENT
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			: >/opt/muos/config/lastplay.txt

--- a/device/rg35xx-sp/input/trigger/sleep.sh
+++ b/device/rg35xx-sp/input/trigger/sleep.sh
@@ -25,11 +25,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		CLOSE_CONTENT
-		if [ "$FG_PROC_VAL" != "retroarch" ]; then
-			: >/opt/muos/config/lastplay.txt
-		fi
-		/opt/muos/script/system/halt.sh poweroff
+		CLOSE_CONTENT_AND_HALT poweroff
 	fi
 
 	sleep 1

--- a/device/rg35xx-sp/input/trigger/sleep.sh
+++ b/device/rg35xx-sp/input/trigger/sleep.sh
@@ -24,6 +24,7 @@ while true; do
 	fi
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
+		/opt/muos/script/system/suspend.sh resume
 		CLOSE_CONTENT
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			: >/opt/muos/config/lastplay.txt

--- a/device/rg40xx/input/trigger/sleep.sh
+++ b/device/rg40xx/input/trigger/sleep.sh
@@ -25,11 +25,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		CLOSE_CONTENT
-		if [ "$FG_PROC_VAL" != "retroarch" ]; then
-			: >/opt/muos/config/lastplay.txt
-		fi
-		/opt/muos/script/system/halt.sh poweroff
+		CLOSE_CONTENT_AND_HALT poweroff
 	fi
 
 	sleep 1

--- a/device/rg40xx/input/trigger/sleep.sh
+++ b/device/rg40xx/input/trigger/sleep.sh
@@ -24,6 +24,7 @@ while true; do
 	fi
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
+		/opt/muos/script/system/suspend.sh resume
 		CLOSE_CONTENT
 		if [ "$FG_PROC_VAL" != "retroarch" ]; then
 			: >/opt/muos/config/lastplay.txt


### PR DESCRIPTION
A few improvements to the sleep timeout shutdown for "Instant Shutdown" and "Sleep XXs + Shutdown" power button modes:

1. Resumes frozen daemons and CPU cores (but still keeps the display blank) before trying to close active content when the sleep timeout expires. This fixes a RetroArch hang caused while `pipewire` is stopped. (See details in #140, which I'm folding into this PR for simplicity.)

2. Fixes an issue where the `CLOSE_CONTENT` operation sometimes hits its full 5 sec timeout unnecessarily. The current code kills the foreground process by name and then polls for five seconds to see if any process with that _name_ is still running. But it doesn't make sure it's the _same_ process.

   That's a problem when long pressing power from the launcher in "Instant Shutdown" mode. We successfully kill the foreground process (`muxlaunch`), but `frontend.sh` starts a new one almost immediately. This new process has the same name, so the loop waits for the full timeout even though the original `muxlaunch` terminated already.

   I rewrote `CLOSE_CONTENT` to find the PID _once_, kill that process by PID, and then loop until that exact process is dead or the timeout expires. This has the same effect when killing, e.g., RetroArch, but avoids hitting the full wait time when killing the launcher.

3. Refactors the shutdown logic currently split across various copies of `sleep.sh` to a common function in `close_game.sh`. (I am looking into reusing this directly from `input.sh` for "Instant Shutdown" in the future to remove the 2+ sec delay that going through `sleep.sh` causes.)