### PR TITLE
Shutdown script tweaks (including unmounting exFAT at the same time as other filesystems)

### DIFF
--- a/script/system/halt.sh
+++ b/script/system/halt.sh
@@ -1,9 +1,16 @@
 #!/bin/sh
 
+# muOS shutdown/reboot script. This behaves a bit better than BusyBox
+# poweroff/reboot commands, which tend to hang (unknown timing issue?), and
+# which also make some odd choices (e.g., unmounting disks before sending
+# SIGTERM to processes, so running programs can't save state to disk.)
+
+# We pass our arguments along to halt_internal.sh, and we also build a list of
+# additional arguments (`set -- "$@" ARGS...`) that halt_internal.sh forwards
+# further to killall5. Specifically, we use `-o PID` params to tell killall5
+# not to kill certain processes too early in the sequence.
 case "$1" in
-	halt|poweroff|reboot)
-		HALT_CMD="$1"
-		;;
+	halt|poweroff|reboot) ;;
 	*)
 		printf 'Usage: %s {halt|poweroff|reboot}\n' "$0" >&2
 		exit 1
@@ -14,10 +21,20 @@ esac
 # killing it. This gives us an easy way to see full script output up to the
 # final halt command.
 if [ "$(readlink "/proc/$PPID/exe")" = /opt/muos/bin/fbpad ]; then
-	OMIT_PID="$PPID"
-else
-	OMIT_PID=
+	set -- "$@" -o "$PPID"
 fi
+
+# exFAT mounts are FUSE filesystems, and they unmount when their usermode FUSE
+# processes are terminated. By default, exFAT partitions would unmount in
+# parallel with cleanup that other programs do on SIGTERM, which could prevent
+# programs that write state to the SD cards from doing so on exit.
+#
+# To avoid that, we omit FUSE mount binaries from our termination process.
+# Instead, the FUSE filesystems are unmounted by `umount -a` just like the
+# kernel filesystems.
+for FUSE_PID in $(pidof /sbin/mount.exfat-fuse); do
+	set -- "$@" -o "$FUSE_PID"
+done
 
 # Our shutdown sequence kills processes using killall5, which sends signals to
 # every process except those in the current session. This means by default, we
@@ -35,5 +52,4 @@ fi
 # Use -w to wait for halt_internal.sh to terminate. On a successful halt, that
 # doesn't really matter, but it allows us to return an appropriate exit status
 # if the shutdown fails partway through.
-exec setsid -fw /opt/muos/script/system/halt_internal.sh "$HALT_CMD" "$OMIT_PID"
-
+exec setsid -fw /opt/muos/script/system/halt_internal.sh "$@"

--- a/script/system/halt_internal.sh
+++ b/script/system/halt_internal.sh
@@ -1,40 +1,27 @@
 #!/bin/sh
 
-# Wraps killall5 and automatically omits the specified PID (if any).
-KILL_PROCS () {
-	if [ -n "$OMIT_PID" ]; then
-		killall5 "$@" -o "$OMIT_PID"
-	else
-		killall5 "$@"
-	fi
-}
-
-# Waits 5 seconds for processes we SIGTERM'd to die. The `killall5 -CONT` trick
-# is inspired by various old sysvinit scripts as a harmless way to check if any
-# processes we targeted with SIGTERM are still alive.
+# Waits 5 seconds for processes to die. The `killall5 -CONT` trick is inspired
+# by various old sysvinit scripts as a harmless way to check if any processes
+# we tried to kill are still alive.
+#
+# Any arguments are passed along to killall5. (Use `-o PID` args to omit
+# certain processes from the existence check.)
 WAIT_FOR_DEATH () {
 	printf 'Waiting for processes to terminate: '
-	for _ in $(seq 5); do
-		sleep 1
+	for _ in $(seq 10); do
+		# Note we sleep *before* the first check, so we always delay
+		# 500ms. This may not be strictly necessary, but seems prudent
+		# given the weird timing issues with shutdown.
+		sleep .5
 		# If killall5 didn't find any processes to signal, they must
 		# all have terminated already, and we can stop waiting.
-		if ! KILL_PROCS -CONT; then
+		if ! killall5 -CONT "$@"; then
 			printf 'done\n'
 			return
 		fi
 	done
-	# After waiting politely a few seconds, let SIGKILL take care of 'em.
 	printf 'timed out\n'
 }
-
-# Sanity check parameters.
-if [ "$#" -ne 2 ]; then
-	printf 'Wrong number of arguments (run halt.sh, not halt_internal.sh)\n' >&2
-	exit 1
-fi
-
-HALT_CMD="$1"
-OMIT_PID="$2"
 
 # Sanity check that SID = PID. (See note on setsid in halt.sh for rationale.)
 if [ "$(cut -d ' ' -f 6 /proc/self/stat)" -ne "$$" ]; then
@@ -42,32 +29,40 @@ if [ "$(cut -d ' ' -f 6 /proc/self/stat)" -ne "$$" ]; then
 	exit 1
 fi
 
+# Sanity check required parameters. Any additional args will be passed to
+# killall5 directly, allowing the caller to specify `-o PID` and safeguard
+# certain processes (e.g., FUSE mounts) from our initial termination pass.
+if [ "$#" -le 1 ]; then
+	printf 'Wrong number of arguments (run halt.sh, not halt_internal.sh)\n' >&2
+	exit 1
+fi
+
+HALT_CMD="$1"
+shift 1
+
 # Stop system services.
-printf 'Stopping init scripts...\n'
+printf 'Running shutdown scripts...\n'
 /etc/init.d/rcK
 
-# Terminate other processes before halting. This is essentially what init
-# should do for us, but for some reason, BusyBox shutdown often hangs. This
-# doesn't seem to. (Why? Not sure, but it may be because we wait for processes
-# to terminate, and don't unmount till they're gone.)
+# Terminate other processes, giving them some time to clean up.
 printf 'Sending SIGTERM to processes...\n'
-KILL_PROCS -TERM
-WAIT_FOR_DEATH
+killall5 -TERM "$@"
+WAIT_FOR_DEATH "$@"
 
 printf 'Sending SIGKILL to processes...\n'
-KILL_PROCS -KILL
+killall5 -KILL "$@"
+WAIT_FOR_DEATH "$@"
 
-# Disable swap (we don't actually have any, but it's standard in shutdown
-# sequences) and cleanly unmount filesystems to avoid fsck/chkdsk errors.
+# Disable swap. (It's not enabled by default, but just in case.)
 printf 'Disabling swap...\n'
 swapoff -a
 
+# Cleanly unmount filesystems to avoid fsck/chkdsk errors.
 printf 'Unmounting filesystems...\n'
-umount -ar
+umount -arv
 
 # Actually halt/shut down/reboot the system. Note the -f so the halt command
 # only calls sync and reboot under the hood, rather than signaling init to
 # start its own buggy shutdown sequence.
 printf 'Going down for %s...\n' "$HALT_CMD"
 "$HALT_CMD" -f
-


### PR DESCRIPTION
Here's what I hope are the last big batch of changes to the new shutdown/reboot flow. I've tested these this afternoon, but they definitely need more verification, as usual with this stuff. Not sure if it's better to merge and let more folks try to ferret out errors, or hold off a day or so. But either way, wanted to get this sent for thoughts. :)

Changes are as follows:

* Updates the way `halt.sh` talks to `halt_internal.sh` to allow passing multiple "omit PIDs" instead of just one. This allows the following....
* Delay unmounting exFAT filesystems until the "Unmounting filesystems..." step where other filesystems (FAT32 SD cards, the rootfs, etc.) unmount. This was my original intent, but I forgot that exFAT was a FUSE filesystem, so it actually unmounted earlier when we SIGTERM'd `mount.exfat`. (The unmount was still clean, but since the exFAT filesystems went away at the same time as other processes were cleaning up, a process trying to dump state to an exFAT SD card on SIGTERM would be hit or miss on whether the write succeeded.)
* Waits for processes to die after SIGKILL, not just SIGTERM. To avoid increasing the net wait time, I reduced the minimum delay in `WAIT_FOR_DEATH` from 1s to 500ms. (It could probably be more like 100ms, but I'm nervous about reducing it too much since we still don't know exactly what causes the lockups that BusyBox shutdown easily triggers.)
* Adds more verbose output (list each FS as it's unmounted). This only shows up if the advanced setting is on anyway, and I think it's useful for now. (Can always rip it out later.)
* Tweaked some text and comments to make a bit more sense.

Example of the new output with an exFAT SD2 card. (Notice that `/mnt/mmc` and `/mount/sdcard` are now unmounted by `umount`. Before this change, they actually unmount during the "Sending SIGTERM to processes..." step instead):

![Delayed exFAT unmount shutdown console logs](https://github.com/user-attachments/assets/51e65465-7da2-4ab0-9459-1561eb3e3f3a)