### PR TITLE
Clean shutdown on muxcharge exit with error status

### DIFF
--- a/device/rg28xx/script/charge.sh
+++ b/device/rg28xx/script/charge.sh
@@ -18,7 +18,9 @@ if [ "$(cat "$DC_BAT_CHARGER")" -eq 1 ] && [ "$GC_BOO_FACTORY_RESET" -eq 0 ]; th
 
 	echo "powersave" >"$DC_CPU_GOVERNOR"
 
-	/opt/muos/extra/muxcharge
+	if ! /opt/muos/extra/muxcharge; then
+		/opt/muos/script/system/halt.sh poweroff
+	fi
 
 	umount "$DC_STO_ROM_MOUNT"
 fi

--- a/device/rg35xx-2024/script/charge.sh
+++ b/device/rg35xx-2024/script/charge.sh
@@ -18,7 +18,9 @@ if [ "$(cat "$DC_BAT_CHARGER")" -eq 1 ] && [ "$GC_BOO_FACTORY_RESET" -eq 0 ]; th
 
 	echo "powersave" >"$DC_CPU_GOVERNOR"
 
-	/opt/muos/extra/muxcharge
+	if ! /opt/muos/extra/muxcharge; then
+		/opt/muos/script/system/halt.sh poweroff
+	fi
 
 	umount "$DC_STO_ROM_MOUNT"
 fi

--- a/device/rg35xx-h/script/charge.sh
+++ b/device/rg35xx-h/script/charge.sh
@@ -18,7 +18,9 @@ if [ "$(cat "$DC_BAT_CHARGER")" -eq 1 ] && [ "$GC_BOO_FACTORY_RESET" -eq 0 ]; th
 
 	echo "powersave" >"$DC_CPU_GOVERNOR"
 
-	/opt/muos/extra/muxcharge
+	if ! /opt/muos/extra/muxcharge; then
+		/opt/muos/script/system/halt.sh poweroff
+	fi
 
 	umount "$DC_STO_ROM_MOUNT"
 fi

--- a/device/rg35xx-plus/script/charge.sh
+++ b/device/rg35xx-plus/script/charge.sh
@@ -18,7 +18,9 @@ if [ "$(cat "$DC_BAT_CHARGER")" -eq 1 ] && [ "$GC_BOO_FACTORY_RESET" -eq 0 ]; th
 
 	echo "powersave" >"$DC_CPU_GOVERNOR"
 
-	/opt/muos/extra/muxcharge
+	if ! /opt/muos/extra/muxcharge; then
+		/opt/muos/script/system/halt.sh poweroff
+	fi
 
 	umount "$DC_STO_ROM_MOUNT"
 fi

--- a/device/rg35xx-sp/script/charge.sh
+++ b/device/rg35xx-sp/script/charge.sh
@@ -18,7 +18,9 @@ if [ "$(cat "$DC_BAT_CHARGER")" -eq 1 ] && [ "$GC_BOO_FACTORY_RESET" -eq 0 ]; th
 
 	echo "powersave" >"$DC_CPU_GOVERNOR"
 
-	/opt/muos/extra/muxcharge
+	if ! /opt/muos/extra/muxcharge; then
+		/opt/muos/script/system/halt.sh poweroff
+	fi
 
 	umount "$DC_STO_ROM_MOUNT"
 fi

--- a/device/rg40xx/script/charge.sh
+++ b/device/rg40xx/script/charge.sh
@@ -20,7 +20,9 @@ if [ "$(cat "$DC_BAT_CHARGER")" -eq 1 ] && [ "$GC_BOO_FACTORY_RESET" -eq 0 ]; th
 
 	echo "powersave" >"$DC_CPU_GOVERNOR"
 
-	/opt/muos/extra/muxcharge
+	if ! /opt/muos/extra/muxcharge; then
+		/opt/muos/script/system/halt.sh poweroff
+	fi
 
 	umount "$DC_STO_ROM_MOUNT"
 fi


### PR DESCRIPTION
We mount the SD1 data partition in the charge flow (and probably should mount the SD2 one too, as currently we fail to load the charger theme from there 😄), but currently `muxcharge` does a `sync`/`reboot` pair itself rather than clean unmount and shutdown. This PR does a clean shutdown from the charge scripts if `muxcharge` returns a nonzero status.

Does nothing on its own, since muxcharge always returns zero, but I have a companion PR for the frontend ready too.