### PR TITLE
Show splash screen (or blank if theme has none) on shutdown/reboot

### DIFF
--- a/script/system/halt.sh
+++ b/script/system/halt.sh
@@ -1,37 +1,42 @@
 #!/bin/sh
 
 # muOS shutdown/reboot script. This behaves a bit better than BusyBox
-# poweroff/reboot commands, which tend to hang (unknown timing issue?), and
-# which also make some odd choices (e.g., unmounting disks before sending
-# SIGTERM to processes, so running programs can't save state to disk.)
+# poweroff/reboot commands, which also make some odd choices (e.g., unmounting
+# disks before killing processes, so running programs can't save state).
+
+. /opt/muos/script/var/global/storage.sh
 
 # We pass our arguments along to halt_internal.sh, and we also build a list of
-# additional arguments (`set -- "$@" ARGS...`) that halt_internal.sh forwards
-# further to killall5. Specifically, we use `-o PID` params to tell killall5
-# not to kill certain processes too early in the sequence.
+# additional arguments (`set -- "$@" ARGS...`) that are forwarded further to
+# killall5. Specifically, we add `-o PID` args below to avoid killing certain
+# processes too early in the sequence.
 case "$1" in
-	halt|poweroff|reboot) ;;
+	halt|poweroff)
+		SPLASH_IMG=shutdown
+		;;
+	reboot)
+		SPLASH_IMG=reboot
+		;;
 	*)
 		printf 'Usage: %s {halt|poweroff|reboot}\n' "$0" >&2
 		exit 1
 		;;
 esac
 
-# As a debugging aid, check if our parent process is fbpad so we can avoid
-# killing it. This gives us an easy way to see full script output up to the
-# final halt command.
 if [ "$(readlink "/proc/$PPID/exe")" = /opt/muos/bin/fbpad ]; then
+	# With verbose messages enabled, we're launched inside fbpad. Avoid
+	# prematurely killing it so console output remains visible.
 	set -- "$@" -o "$PPID"
+else
+	# Otherwise, show a theme-provided splash screen to give immediate
+	# visual feedback since the shutdown sequence can take a few seconds.
+	# (If muxsplash can't find the image, it simply clears the screen.)
+	/opt/muos/extra/muxsplash "$GC_STO_THEME/MUOS/theme/active/image/$SPLASH_IMG.png"
 fi
 
-# exFAT mounts are FUSE filesystems, and they unmount when their usermode FUSE
-# processes are terminated. By default, exFAT partitions would unmount in
-# parallel with cleanup that other programs do on SIGTERM, which could prevent
-# programs that write state to the SD cards from doing so on exit.
-#
-# To avoid that, we omit FUSE mount binaries from our termination process.
-# Instead, the FUSE filesystems are unmounted by `umount -a` just like the
-# kernel filesystems.
+# Omit FUSE mount binaries from the termination process. Otherwise, FUSE
+# filesystems (e.g., exFAT) would unmount in parallel with other programs
+# exiting, preventing them from writing state to the SD card during cleanup.
 for FUSE_PID in $(pidof /sbin/mount.exfat-fuse); do
 	set -- "$@" -o "$FUSE_PID"
 done
@@ -39,7 +44,7 @@ done
 # Our shutdown sequence kills processes using killall5, which sends signals to
 # every process except those in the current session. This means by default, we
 # might miss killing some processes (e.g., background jobs in the same shell as
-# halt.sh is invoked.)
+# halt.sh is invoked).
 #
 # We address this by wrapping the actual shutdown sequence in a setsid command,
 # ensuring we invoke killall5 from a new (and otherwise empty) session.


### PR DESCRIPTION
As discussed w/ @xonglebongle and @VagueParade on Discord. The new shutdown flow takes a couple seconds to complete (a little longer if some process has a lot of state to flush to disk), so having immediate visual feedback when the user decides to shut down helps a lot. Also, splash screens are pretty. 😄

This PR updates the shutdown flow to run `muxsplash` (not a thing yet, but I hear it will be soon 😃) with `shutdown.bmp` or `reboot.bmp` if it exists. And if the theme doesn't provide a splash image, we blank the display instead, which still makes the shutdown process feel more responsive (even if it's actually taking just as long as before).

Couple notes for posterity: doing this in `halt.sh` so we get the same behavior regardless of how shutdown is triggered (e.g., for the "emergency reboot" hotkey I'm planning to add soon). Also, not using existing binaries `fbv` (too slow) or `fbsplash` (only PPM support) since they won't handle rotated displays correctly.

I added some helper functions in `func.sh` to cut down on the `dispdbg` boilerplate, hope that's cool. I also updated the existing `dispdbg` uses in the device scripts to call the helpers instead. Adds a bunch of files to the PR unfortunately; however, that's in its [own commit](https://github.com/MustardOS/internal/pull/150/commits/959ba9c4b8930147eca63133a8d4caa927166170), so if you want it separately or not at all, you can just discard that one commit when merging.