### PR TITLE
Emergency reboot hotkey (Power+L1+L2+R1+R2)

### DIFF
--- a/device/rg28xx/input/input.sh
+++ b/device/rg28xx/input/input.sh
@@ -89,14 +89,19 @@ fi
 		esac
 	fi
 
+	# Power long press combos:
 	if [ "$COUNT_POWER_LONG" -eq 1 ]; then
 		. /opt/muos/script/var/global/setting_general.sh
-
 		COUNT_POWER_LONG=0
-		if [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			# When the user presses power to wake from suspend, the
-			# press/release events are received by our evtest loop
-			# after wakeup. A long press sends us right back here.
+
+		if [ "$STATE_L1:$STATE_L2:$STATE_R1:$STATE_R2" = 1:1:1:1 ]; then
+			# Power+L1+L2+R1+R2: Emergency reboot
+			#
+			# This blocks the input loop so we don't try to process
+			# more hotkeys while rebooting.
+			/opt/muos/script/system/halt.sh reboot
+		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
+			# Power: Suspend
 			#
 			# Avoid suspending again immediately by ignoring power
 			# long presses processed within 100ms of wakeup.
@@ -105,6 +110,7 @@ fi
 				RESUME_UPTIME="$(UPTIME)"
 			fi
 		else
+			# Power: Sleep
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then
 				echo on >$TMP_POWER_LONG

--- a/device/rg35xx-2024/input/input.sh
+++ b/device/rg35xx-2024/input/input.sh
@@ -88,14 +88,19 @@ fi
 		esac
 	fi
 
+	# Power long press combos:
 	if [ "$COUNT_POWER_LONG" -eq 1 ]; then
 		. /opt/muos/script/var/global/setting_general.sh
-
 		COUNT_POWER_LONG=0
-		if [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			# When the user presses power to wake from suspend, the
-			# press/release events are received by our evtest loop
-			# after wakeup. A long press sends us right back here.
+
+		if [ "$STATE_L1:$STATE_L2:$STATE_R1:$STATE_R2" = 1:1:1:1 ]; then
+			# Power+L1+L2+R1+R2: Emergency reboot
+			#
+			# This blocks the input loop so we don't try to process
+			# more hotkeys while rebooting.
+			/opt/muos/script/system/halt.sh reboot
+		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
+			# Power: Suspend
 			#
 			# Avoid suspending again immediately by ignoring power
 			# long presses processed within 100ms of wakeup.
@@ -104,6 +109,7 @@ fi
 				RESUME_UPTIME="$(UPTIME)"
 			fi
 		else
+			# Power: Sleep
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then
 				echo on >$TMP_POWER_LONG

--- a/device/rg35xx-h/input/input.sh
+++ b/device/rg35xx-h/input/input.sh
@@ -77,14 +77,19 @@ fi
 		esac
 	fi
 
+	# Power long press combos:
 	if [ "$COUNT_POWER_LONG" -eq 1 ]; then
 		. /opt/muos/script/var/global/setting_general.sh
-
 		COUNT_POWER_LONG=0
-		if [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			# When the user presses power to wake from suspend, the
-			# press/release events are received by our evtest loop
-			# after wakeup. A long press sends us right back here.
+
+		if [ "$STATE_L1:$STATE_L2:$STATE_R1:$STATE_R2" = 1:1:1:1 ]; then
+			# Power+L1+L2+R1+R2: Emergency reboot
+			#
+			# This blocks the input loop so we don't try to process
+			# more hotkeys while rebooting.
+			/opt/muos/script/system/halt.sh reboot
+		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
+			# Power: Suspend
 			#
 			# Avoid suspending again immediately by ignoring power
 			# long presses processed within 100ms of wakeup.
@@ -93,6 +98,7 @@ fi
 				RESUME_UPTIME="$(UPTIME)"
 			fi
 		else
+			# Power: Sleep
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then
 				echo on >$TMP_POWER_LONG

--- a/device/rg35xx-plus/input/input.sh
+++ b/device/rg35xx-plus/input/input.sh
@@ -88,14 +88,19 @@ fi
 		esac
 	fi
 
+	# Power long press combos:
 	if [ "$COUNT_POWER_LONG" -eq 1 ]; then
 		. /opt/muos/script/var/global/setting_general.sh
-
 		COUNT_POWER_LONG=0
-		if [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			# When the user presses power to wake from suspend, the
-			# press/release events are received by our evtest loop
-			# after wakeup. A long press sends us right back here.
+
+		if [ "$STATE_L1:$STATE_L2:$STATE_R1:$STATE_R2" = 1:1:1:1 ]; then
+			# Power+L1+L2+R1+R2: Emergency reboot
+			#
+			# This blocks the input loop so we don't try to process
+			# more hotkeys while rebooting.
+			/opt/muos/script/system/halt.sh reboot
+		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
+			# Power: Suspend
 			#
 			# Avoid suspending again immediately by ignoring power
 			# long presses processed within 100ms of wakeup.
@@ -104,6 +109,7 @@ fi
 				RESUME_UPTIME="$(UPTIME)"
 			fi
 		else
+			# Power: Sleep
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then
 				echo on >$TMP_POWER_LONG

--- a/device/rg35xx-sp/input/input.sh
+++ b/device/rg35xx-sp/input/input.sh
@@ -89,14 +89,19 @@ fi
 		esac
 	fi
 
+	# Power long press combos:
 	if [ "$COUNT_POWER_LONG" -eq 1 ]; then
 		. /opt/muos/script/var/global/setting_general.sh
-
 		COUNT_POWER_LONG=0
-		if [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			# When the user presses power to wake from suspend, the
-			# press/release events are received by our evtest loop
-			# after wakeup. A long press sends us right back here.
+
+		if [ "$STATE_L1:$STATE_L2:$STATE_R1:$STATE_R2" = 1:1:1:1 ]; then
+			# Power+L1+L2+R1+R2: Emergency reboot
+			#
+			# This blocks the input loop so we don't try to process
+			# more hotkeys while rebooting.
+			/opt/muos/script/system/halt.sh reboot
+		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
+			# Power: Suspend
 			#
 			# Avoid suspending again immediately by ignoring power
 			# long presses processed within 100ms of wakeup.
@@ -105,6 +110,7 @@ fi
 				RESUME_UPTIME="$(UPTIME)"
 			fi
 		else
+			# Power: Sleep
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then
 				echo on >$TMP_POWER_LONG

--- a/device/rg40xx/input/input.sh
+++ b/device/rg40xx/input/input.sh
@@ -78,14 +78,19 @@ fi
 		esac
 	fi
 
+	# Power long press combos:
 	if [ "$COUNT_POWER_LONG" -eq 1 ]; then
 		. /opt/muos/script/var/global/setting_general.sh
-
 		COUNT_POWER_LONG=0
-		if [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			# When the user presses power to wake from suspend, the
-			# press/release events are received by our evtest loop
-			# after wakeup. A long press sends us right back here.
+
+		if [ "$STATE_L1:$STATE_L2:$STATE_R1:$STATE_R2" = 1:1:1:1 ]; then
+			# Power+L1+L2+R1+R2: Emergency reboot
+			#
+			# This blocks the input loop so we don't try to process
+			# more hotkeys while rebooting.
+			/opt/muos/script/system/halt.sh reboot
+		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
+			# Power: Suspend
 			#
 			# Avoid suspending again immediately by ignoring power
 			# long presses processed within 100ms of wakeup.
@@ -94,6 +99,7 @@ fi
 				RESUME_UPTIME="$(UPTIME)"
 			fi
 		else
+			# Power: Sleep
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then
 				echo on >$TMP_POWER_LONG


### PR DESCRIPTION
Long press Power while holding L1+L2+R1+R2 to do an immediate (but clean) reboot. Should help avoid truncated files and such when the foreground app hangs and SSH isn't available. (At minimum, it's a better choice than the reset button. :P)

Even works with the splash screen! One caveat is that the hotkey doesn't currently show the console output when "Verbose Messages" is on. I have an idea about that (basically I want to move the `fbpad` invocation into `halt.sh` as it lets us clean up some of the "omit PID from death" messiness), but won't get to it for a couple days because Real Life.