### PR TITLE
Merge the various halt codepaths and clear last game on OSF reboot

### DIFF
--- a/device/rg28xx/input/input.sh
+++ b/device/rg28xx/input/input.sh
@@ -8,6 +8,8 @@
 . /opt/muos/script/var/global/setting_general.sh
 . /opt/muos/script/var/global/setting_advanced.sh
 
+. /opt/muos/script/mux/close_game.sh
+
 mkdir -p /tmp/combo
 mkdir -p /tmp/trigger
 
@@ -99,7 +101,7 @@ fi
 			#
 			# This blocks the input loop so we don't try to process
 			# more hotkeys while rebooting.
-			/opt/muos/script/system/halt.sh reboot
+			HALT_SYSTEM osf reboot
 		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
 			# Power: Suspend
 			#

--- a/device/rg28xx/input/trigger/sleep.sh
+++ b/device/rg28xx/input/trigger/sleep.sh
@@ -25,7 +25,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		CLOSE_CONTENT_AND_HALT poweroff
+		HALT_SYSTEM sleep poweroff
 	fi
 
 	sleep 1

--- a/device/rg35xx-2024/input/input.sh
+++ b/device/rg35xx-2024/input/input.sh
@@ -7,6 +7,8 @@
 . /opt/muos/script/var/global/boot.sh
 . /opt/muos/script/var/global/setting_advanced.sh
 
+. /opt/muos/script/mux/close_game.sh
+
 mkdir -p /tmp/combo
 mkdir -p /tmp/trigger
 
@@ -98,7 +100,7 @@ fi
 			#
 			# This blocks the input loop so we don't try to process
 			# more hotkeys while rebooting.
-			/opt/muos/script/system/halt.sh reboot
+			HALT_SYSTEM osf reboot
 		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
 			# Power: Suspend
 			#

--- a/device/rg35xx-2024/input/trigger/sleep.sh
+++ b/device/rg35xx-2024/input/trigger/sleep.sh
@@ -25,7 +25,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		CLOSE_CONTENT_AND_HALT poweroff
+		HALT_SYSTEM sleep poweroff
 	fi
 
 	sleep 1

--- a/device/rg35xx-h/input/input.sh
+++ b/device/rg35xx-h/input/input.sh
@@ -7,6 +7,8 @@
 . /opt/muos/script/var/global/boot.sh
 . /opt/muos/script/var/global/setting_advanced.sh
 
+. /opt/muos/script/mux/close_game.sh
+
 mkdir -p /tmp/combo
 mkdir -p /tmp/trigger
 
@@ -87,7 +89,7 @@ fi
 			#
 			# This blocks the input loop so we don't try to process
 			# more hotkeys while rebooting.
-			/opt/muos/script/system/halt.sh reboot
+			HALT_SYSTEM osf reboot
 		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
 			# Power: Suspend
 			#

--- a/device/rg35xx-h/input/trigger/sleep.sh
+++ b/device/rg35xx-h/input/trigger/sleep.sh
@@ -25,7 +25,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		CLOSE_CONTENT_AND_HALT poweroff
+		HALT_SYSTEM sleep poweroff
 	fi
 
 	sleep 1

--- a/device/rg35xx-plus/input/input.sh
+++ b/device/rg35xx-plus/input/input.sh
@@ -7,6 +7,8 @@
 . /opt/muos/script/var/global/boot.sh
 . /opt/muos/script/var/global/setting_advanced.sh
 
+. /opt/muos/script/mux/close_game.sh
+
 mkdir -p /tmp/combo
 mkdir -p /tmp/trigger
 
@@ -98,7 +100,7 @@ fi
 			#
 			# This blocks the input loop so we don't try to process
 			# more hotkeys while rebooting.
-			/opt/muos/script/system/halt.sh reboot
+			HALT_SYSTEM osf reboot
 		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
 			# Power: Suspend
 			#

--- a/device/rg35xx-plus/input/trigger/sleep.sh
+++ b/device/rg35xx-plus/input/trigger/sleep.sh
@@ -25,7 +25,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		CLOSE_CONTENT_AND_HALT poweroff
+		HALT_SYSTEM sleep poweroff
 	fi
 
 	sleep 1

--- a/device/rg35xx-sp/input/input.sh
+++ b/device/rg35xx-sp/input/input.sh
@@ -7,6 +7,8 @@
 . /opt/muos/script/var/global/boot.sh
 . /opt/muos/script/var/global/setting_advanced.sh
 
+. /opt/muos/script/mux/close_game.sh
+
 mkdir -p /tmp/combo
 mkdir -p /tmp/trigger
 
@@ -99,7 +101,7 @@ fi
 			#
 			# This blocks the input loop so we don't try to process
 			# more hotkeys while rebooting.
-			/opt/muos/script/system/halt.sh reboot
+			HALT_SYSTEM osf reboot
 		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
 			# Power: Suspend
 			#

--- a/device/rg35xx-sp/input/trigger/sleep.sh
+++ b/device/rg35xx-sp/input/trigger/sleep.sh
@@ -25,7 +25,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		CLOSE_CONTENT_AND_HALT poweroff
+		HALT_SYSTEM sleep poweroff
 	fi
 
 	sleep 1

--- a/device/rg40xx/input/input.sh
+++ b/device/rg40xx/input/input.sh
@@ -8,6 +8,8 @@
 . /opt/muos/script/var/global/setting_advanced.sh
 . /opt/muos/script/var/global/setting_general.sh
 
+. /opt/muos/script/mux/close_game.sh
+
 mkdir -p /tmp/combo
 mkdir -p /tmp/trigger
 
@@ -88,7 +90,7 @@ fi
 			#
 			# This blocks the input loop so we don't try to process
 			# more hotkeys while rebooting.
-			/opt/muos/script/system/halt.sh reboot
+			HALT_SYSTEM osf reboot
 		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
 			# Power: Suspend
 			#

--- a/device/rg40xx/input/trigger/sleep.sh
+++ b/device/rg40xx/input/trigger/sleep.sh
@@ -25,7 +25,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$GC_GEN_SHUTDOWN" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		CLOSE_CONTENT_AND_HALT poweroff
+		HALT_SYSTEM sleep poweroff
 	fi
 
 	sleep 1

--- a/script/mux/close_game.sh
+++ b/script/mux/close_game.sh
@@ -1,12 +1,16 @@
 #!/bin/sh
 
+. /opt/muos/script/var/func.sh
+
+# Attempts to cleanly close the current foreground process, resuming it first
+# if it's stopped. Waits five seconds before giving up.
 CLOSE_CONTENT() {
 	FG_PROC_VAL="$(cat /tmp/fg_proc)"
 	FG_PROC_PID="$(pidof "$FG_PROC_VAL")"
 	if [ -n "$FG_PROC_PID" ]; then
-		kill -CONT "$FG_PROC_PID"
-		kill "$FG_PROC_PID"
-		for TIMEOUT in $(seq 1 20); do
+		kill -CONT "$FG_PROC_PID" 2>/dev/null
+		kill "$FG_PROC_PID" 2>/dev/null
+		for _ in $(seq 1 20); do
 			if ! kill -0 "$FG_PROC_PID" 2>/dev/null; then
 				break
 			fi
@@ -15,10 +19,54 @@ CLOSE_CONTENT() {
 	fi
 }
 
-CLOSE_CONTENT_AND_HALT() {
-	CLOSE_CONTENT
-	if [ "$FG_PROC_VAL" != "retroarch" ]; then
-		: >/opt/muos/config/lastplay.txt
+# Cleanly halts, shuts down, or reboots the device.
+#
+# Usage: HALT_SYSTEM SRC CMD
+#
+# SRC allows specific based on how the halt was triggered. Current values are
+# "frontend" (from launcher UI), "osf" (emergency reboot hotkey), and "sleep"
+# (sleep timeout, possibly while playing content).
+#
+# CMD is one of "halt", "poweroff", or "reboot" and corresponds to the usual
+# meaning of those programs.
+HALT_SYSTEM () {
+	. /opt/muos/script/var/global/setting_advanced.sh
+	. /opt/muos/script/var/global/setting_general.sh
+
+	HALT_SRC="$1"
+	HALT_CMD="$2"
+
+	# Clear state we never want to persist across reboots.
+	: >/opt/muos/config/address.txt
+
+	case "$HALT_SRC" in
+		frontend)
+			# Unless startup option is "last game", clear last
+			# played so we don't rerun it on the next boot.
+			if [ "$GC_GEN_STARTUP" != last ]; then
+				: >/opt/muos/config/lastplay.txt
+			fi
+			;;
+		osf)
+			# Always clear last played on emergency halt in case
+			# the content itself is what forced the user to reboot.
+			: >/opt/muos/config/lastplay.txt
+			;;
+		sleep)
+			CLOSE_CONTENT
+			# Only support "last game" and "resume game" startup
+			# options for RetroArch; clear last played otherwise.
+			if [ "$FG_PROC_VAL" != retroarch ]; then
+				: >/opt/muos/config/lastplay.txt
+			fi
+			;;
+	esac
+
+	# When "verbose messages" setting is enabled, run the actual halt
+	# script in fbpad so its output is visible on screen.
+	if [ "$GC_ADV_VERBOSE" -eq 1 ]; then
+		/opt/muos/bin/fbpad /opt/muos/script/system/halt.sh "$HALT_CMD" </dev/null
+	else
+		/opt/muos/script/system/halt.sh "$HALT_CMD"
 	fi
-	/opt/muos/script/system/halt.sh "$1"
 }

--- a/script/mux/frontend.sh
+++ b/script/mux/frontend.sh
@@ -10,6 +10,8 @@
 . /opt/muos/script/var/global/network.sh
 . /opt/muos/script/var/global/storage.sh
 
+. /opt/muos/script/mux/close_game.sh
+
 if [ "$DC_DEV_NAME" = "RG40XX" ]; then
 	/opt/muos/device/rg40xx/script/led_control.sh 1 0 0 0 0 0 0 0
 fi
@@ -30,20 +32,6 @@ echo "root" >$EX_CARD
 KILL_BGM() {
 	if pgrep -f "playbgm.sh" >/dev/null; then
 		killall -q "playbgm.sh" "mpg123"
-	fi
-}
-
-PREPARE_HALT() {
-	. /opt/muos/script/var/global/setting_advanced.sh
-	. /opt/muos/script/var/global/setting_general.sh
-	: >/opt/muos/config/address.txt
-	if [ "$GC_GEN_STARTUP" = resume ]; then
-		: >/opt/muos/config/lastplay.txt
-	fi
-	if [ "$GC_ADV_VERBOSE" -eq 1 ]; then
-		/opt/muos/bin/fbpad /opt/muos/script/system/halt.sh "$1"
-	else
-		/opt/muos/script/system/halt.sh "$1"
 	fi
 }
 
@@ -322,10 +310,10 @@ while true; do
 				nice --20 /opt/muos/extra/muxcredits
 				;;
 			"reboot")
-				PREPARE_HALT reboot
+				HALT_SYSTEM frontend reboot
 				;;
 			"shutdown")
-				PREPARE_HALT poweroff
+				HALT_SYSTEM frontend poweroff
 				;;
 		esac
 	fi

--- a/script/system/halt.sh
+++ b/script/system/halt.sh
@@ -6,21 +6,20 @@
 
 . /opt/muos/script/var/global/storage.sh
 
-# We pass our arguments along to halt_internal.sh, and we also build a list of
-# additional arguments (`set -- "$@" ARGS...`) that are forwarded further to
-# killall5. Specifically, we add `-o PID` args below to avoid killing certain
-# processes too early in the sequence.
+USAGE () {
+	printf 'Usage: %s {halt|poweroff|reboot}\n' "$0" >&2
+	exit 1
+}
+
+# We pass our arguments along to halt_internal.sh, which forwards extra args to
+# killall5. In particular, we can append `-o PID` arguments to avoid killing
+# specific processes too early in the sequence.
+[ "$#" -eq 1 ] || USAGE
+
 case "$1" in
-	halt|poweroff)
-		SPLASH_IMG=shutdown
-		;;
-	reboot)
-		SPLASH_IMG=reboot
-		;;
-	*)
-		printf 'Usage: %s {halt|poweroff|reboot}\n' "$0" >&2
-		exit 1
-		;;
+	halt|poweroff) SPLASH_IMG=shutdown ;;
+	reboot) SPLASH_IMG=reboot ;;
+	*) USAGE ;;
 esac
 
 if [ "$(readlink "/proc/$PPID/exe")" = /opt/muos/bin/fbpad ]; then


### PR DESCRIPTION
Related to [Discord thread](https://discord.com/channels/1152022492001603615/1271556930678030436). Basically, this started as a one-liner to clear the last played game when the emergency reboot hotkey is activated (in case the game itself is what locked up the system in the first place). But it grew a bit, as I realized some other inconsistencies in the various different shutdown/reboot codepaths that muOS now has.

I ended up putting a `HALT_SYSTEM` function in `close_game.sh` (since that's where `CLOSE_CONTENT` already lives, and it seemed like a good place for shutdown stuff too) that takes a `HALT_SRC` as a param and uses that to determine how it should clean up the last played files, etc.

One advantage of this is that we also get verbose message integration for the OSF reboot "for free", which is neat. :)

I think the only places not using `HALT_SYSTEM` after this PR are 1) the shutdown in charge mode when the cable is pulled and 2) the reboot on factory reset. I guess we could use it there too, but I don't think it buys us anything since the system isn't "running normally" in those modes and we probably don't care about extra cleanup, advanced prefs, etc. as much there.