### PR TITLE
Bypass sleep delay on instant shutdown

### DIFF
--- a/device/rg28xx/input/input.sh
+++ b/device/rg28xx/input/input.sh
@@ -97,13 +97,10 @@ fi
 		COUNT_POWER_LONG=0
 
 		if [ "$STATE_L1:$STATE_L2:$STATE_R1:$STATE_R2" = 1:1:1:1 ]; then
-			# Power+L1+L2+R1+R2: Emergency reboot
-			#
-			# This blocks the input loop so we don't try to process
-			# more hotkeys while rebooting.
+			# Power+L1+L2+R1+R2: Overall System Failsafe (Reboot)
 			HALT_SYSTEM osf reboot
 		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			# Power: Suspend
+			# Power: Sleep Suspend
 			#
 			# Avoid suspending again immediately by ignoring power
 			# long presses processed within 100ms of wakeup.
@@ -111,8 +108,11 @@ fi
 				/opt/muos/script/system/suspend.sh power
 				RESUME_UPTIME="$(UPTIME)"
 			fi
+		elif [ "$GC_GEN_SHUTDOWN" -eq 2 ]; then
+			# Power: Instant Shutdown
+			HALT_SYSTEM sleep poweroff
 		else
-			# Power: Sleep
+			# Power: Sleep XXs + Shutdown
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then
 				echo on >$TMP_POWER_LONG

--- a/device/rg35xx-2024/input/input.sh
+++ b/device/rg35xx-2024/input/input.sh
@@ -96,13 +96,10 @@ fi
 		COUNT_POWER_LONG=0
 
 		if [ "$STATE_L1:$STATE_L2:$STATE_R1:$STATE_R2" = 1:1:1:1 ]; then
-			# Power+L1+L2+R1+R2: Emergency reboot
-			#
-			# This blocks the input loop so we don't try to process
-			# more hotkeys while rebooting.
+			# Power+L1+L2+R1+R2: Overall System Failsafe (Reboot)
 			HALT_SYSTEM osf reboot
 		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			# Power: Suspend
+			# Power: Sleep Suspend
 			#
 			# Avoid suspending again immediately by ignoring power
 			# long presses processed within 100ms of wakeup.
@@ -110,8 +107,11 @@ fi
 				/opt/muos/script/system/suspend.sh power
 				RESUME_UPTIME="$(UPTIME)"
 			fi
+		elif [ "$GC_GEN_SHUTDOWN" -eq 2 ]; then
+			# Power: Instant Shutdown
+			HALT_SYSTEM sleep poweroff
 		else
-			# Power: Sleep
+			# Power: Sleep XXs + Shutdown
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then
 				echo on >$TMP_POWER_LONG

--- a/device/rg35xx-h/input/input.sh
+++ b/device/rg35xx-h/input/input.sh
@@ -85,13 +85,10 @@ fi
 		COUNT_POWER_LONG=0
 
 		if [ "$STATE_L1:$STATE_L2:$STATE_R1:$STATE_R2" = 1:1:1:1 ]; then
-			# Power+L1+L2+R1+R2: Emergency reboot
-			#
-			# This blocks the input loop so we don't try to process
-			# more hotkeys while rebooting.
+			# Power+L1+L2+R1+R2: Overall System Failsafe (Reboot)
 			HALT_SYSTEM osf reboot
 		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			# Power: Suspend
+			# Power: Sleep Suspend
 			#
 			# Avoid suspending again immediately by ignoring power
 			# long presses processed within 100ms of wakeup.
@@ -99,8 +96,11 @@ fi
 				/opt/muos/script/system/suspend.sh power
 				RESUME_UPTIME="$(UPTIME)"
 			fi
+		elif [ "$GC_GEN_SHUTDOWN" -eq 2 ]; then
+			# Power: Instant Shutdown
+			HALT_SYSTEM sleep poweroff
 		else
-			# Power: Sleep
+			# Power: Sleep XXs + Shutdown
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then
 				echo on >$TMP_POWER_LONG

--- a/device/rg35xx-plus/input/input.sh
+++ b/device/rg35xx-plus/input/input.sh
@@ -96,13 +96,10 @@ fi
 		COUNT_POWER_LONG=0
 
 		if [ "$STATE_L1:$STATE_L2:$STATE_R1:$STATE_R2" = 1:1:1:1 ]; then
-			# Power+L1+L2+R1+R2: Emergency reboot
-			#
-			# This blocks the input loop so we don't try to process
-			# more hotkeys while rebooting.
+			# Power+L1+L2+R1+R2: Overall System Failsafe (Reboot)
 			HALT_SYSTEM osf reboot
 		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			# Power: Suspend
+			# Power: Sleep Suspend
 			#
 			# Avoid suspending again immediately by ignoring power
 			# long presses processed within 100ms of wakeup.
@@ -110,8 +107,11 @@ fi
 				/opt/muos/script/system/suspend.sh power
 				RESUME_UPTIME="$(UPTIME)"
 			fi
+		elif [ "$GC_GEN_SHUTDOWN" -eq 2 ]; then
+			# Power: Instant Shutdown
+			HALT_SYSTEM sleep poweroff
 		else
-			# Power: Sleep
+			# Power: Sleep XXs + Shutdown
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then
 				echo on >$TMP_POWER_LONG

--- a/device/rg35xx-sp/input/input.sh
+++ b/device/rg35xx-sp/input/input.sh
@@ -97,13 +97,10 @@ fi
 		COUNT_POWER_LONG=0
 
 		if [ "$STATE_L1:$STATE_L2:$STATE_R1:$STATE_R2" = 1:1:1:1 ]; then
-			# Power+L1+L2+R1+R2: Emergency reboot
-			#
-			# This blocks the input loop so we don't try to process
-			# more hotkeys while rebooting.
+			# Power+L1+L2+R1+R2: Overall System Failsafe (Reboot)
 			HALT_SYSTEM osf reboot
 		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			# Power: Suspend
+			# Power: Sleep Suspend
 			#
 			# Avoid suspending again immediately by ignoring power
 			# long presses processed within 100ms of wakeup.
@@ -111,8 +108,11 @@ fi
 				/opt/muos/script/system/suspend.sh power
 				RESUME_UPTIME="$(UPTIME)"
 			fi
+		elif [ "$GC_GEN_SHUTDOWN" -eq 2 ]; then
+			# Power: Instant Shutdown
+			HALT_SYSTEM sleep poweroff
 		else
-			# Power: Sleep
+			# Power: Sleep XXs + Shutdown
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then
 				echo on >$TMP_POWER_LONG

--- a/device/rg40xx/input/input.sh
+++ b/device/rg40xx/input/input.sh
@@ -86,13 +86,10 @@ fi
 		COUNT_POWER_LONG=0
 
 		if [ "$STATE_L1:$STATE_L2:$STATE_R1:$STATE_R2" = 1:1:1:1 ]; then
-			# Power+L1+L2+R1+R2: Emergency reboot
-			#
-			# This blocks the input loop so we don't try to process
-			# more hotkeys while rebooting.
+			# Power+L1+L2+R1+R2: Overall System Failsafe (Reboot)
 			HALT_SYSTEM osf reboot
 		elif [ "$GC_GEN_SHUTDOWN" -eq -1 ]; then
-			# Power: Suspend
+			# Power: Sleep Suspend
 			#
 			# Avoid suspending again immediately by ignoring power
 			# long presses processed within 100ms of wakeup.
@@ -100,8 +97,11 @@ fi
 				/opt/muos/script/system/suspend.sh power
 				RESUME_UPTIME="$(UPTIME)"
 			fi
+		elif [ "$GC_GEN_SHUTDOWN" -eq 2 ]; then
+			# Power: Instant Shutdown
+			HALT_SYSTEM sleep poweroff
 		else
-			# Power: Sleep
+			# Power: Sleep XXs + Shutdown
 			TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 			if [ ! -e $TMP_POWER_LONG ]; then
 				echo on >$TMP_POWER_LONG


### PR DESCRIPTION
Last shutdown tweak, I think, for real this time. "Instant Shutdown" is the mode I actually use, and I want to make it a little "instanter".

Right now, it's implemented using the normal sleep mode with a 2 second delay. So when you long press power, the device 1) goes to sleep (blanking the display), 2) sleeps 2s, 3) wakes up (but keeps the display blanked), 4) closes content, and finally 5) shuts down.

Now that we have the new shutdown script and common helper for it in `close_game.sh`, it's easy to shorten this: 1) close content, 2) shut down. In addition to making instant shutdown more responsive, this also means the shutdown splash image is now visible for instant shutdown (which I think makes sense since we don't call it a sleep mode in the UI, that was just an implementation detail).

One thing that's a little weird: the `GC_GEN_SHUTDOWN` value for "Instant Shutdown" is 2, which is a holdover of the old 2s sleep implementation. I feel like 0 would make more sense, but I don't know if that's something we should change, or if we want to keep using 2 since it's in existing configs....

P.S. I gave "OSF" one possible acronym expansion in the comments, just for fun or if we need one for the docs. :P