### PR TITLE
Fix LED-Controller (RG40XX-H)

### DIFF
--- a/device/rg40xx-h/script/charge.sh
+++ b/device/rg40xx-h/script/charge.sh
@@ -10,7 +10,7 @@
 . /opt/muos/script/var/global/boot.sh
 
 if [ "$(cat "$DC_BAT_CHARGER")" -eq 1 ] && [ "$GC_BOO_FACTORY_RESET" -eq 0 ]; then
-	/opt/muos/device/rg40xx/script/led_control.sh 1 0 0 0 0 0 0 0
+	/opt/muos/device/rg40xx-h/script/led_control.sh 1 0 0 0 0 0 0 0
 
 	mount -t "$DC_STO_ROM_TYPE" -o rw,utf8,noatime,nofail /dev/"$DC_STO_ROM_DEV"p"$DC_STO_ROM_NUM" "$DC_STO_ROM_MOUNT"
 

--- a/script/mux/frontend.sh
+++ b/script/mux/frontend.sh
@@ -12,8 +12,8 @@
 
 . /opt/muos/script/mux/close_game.sh
 
-if [ "$DC_DEV_NAME" = "RG40XX" ]; then
-	/opt/muos/device/rg40xx/script/led_control.sh 1 0 0 0 0 0 0 0
+if [ "$DC_DEV_NAME" = "RG40XX-H" ]; then
+	/opt/muos/device/rg40xx-h/script/led_control.sh 1 0 0 0 0 0 0 0
 fi
 
 ACT_GO=/tmp/act_go

--- a/script/system/startup.sh
+++ b/script/system/startup.sh
@@ -11,8 +11,8 @@
 . /opt/muos/script/var/global/setting_advanced.sh
 . /opt/muos/script/var/global/setting_general.sh
 
-if [ "$DC_DEV_NAME" = "RG40XX" ]; then
-	/opt/muos/device/rg40xx/script/led_control.sh 2 255 225 173 1
+if [ "$DC_DEV_NAME" = "RG40XX-H" ]; then
+	/opt/muos/device/rg40xx-h/script/led_control.sh 2 255 225 173 1
 fi
 
 AUDIO_SRC="/tmp/mux_audio_src"


### PR DESCRIPTION
After the recent name change of the device folder the LED-Controller path and device name is incorrect. Preventing the LED-rings to work on startup.