### PR TITLE
Blank screen on "Instant Shutdown" and OSF hotkey

### DIFF
--- a/script/mux/close_game.sh
+++ b/script/mux/close_game.sh
@@ -2,6 +2,8 @@
 
 . /opt/muos/script/var/func.sh
 
+. /opt/muos/script/var/device/device.sh
+
 # Attempts to cleanly close the current foreground process, resuming it first
 # if it's stopped. Waits five seconds before giving up.
 CLOSE_CONTENT() {
@@ -32,15 +34,30 @@ CLOSE_CONTENT() {
 HALT_SYSTEM () {
 	. /opt/muos/script/var/global/setting_advanced.sh
 	. /opt/muos/script/var/global/setting_general.sh
+	. /opt/muos/script/var/global/storage.sh
 
 	HALT_SRC="$1"
 	HALT_CMD="$2"
+
+	case "$HALT_CMD" in
+		halt|poweroff) SPLASH_IMG=shutdown ;;
+		reboot) SPLASH_IMG=reboot ;;
+	esac
+
+	# Turn on power LED for consistency across different halt codepaths.
+	echo 1 >"$DC_DEV_LED"
 
 	# Clear state we never want to persist across reboots.
 	: >/opt/muos/config/address.txt
 
 	case "$HALT_SRC" in
 		frontend)
+			# When not showing verbose output, display a
+			# theme-provided splash screen during shutdown.
+			if [ "$GC_ADV_VERBOSE" -eq 0 ]; then
+				/opt/muos/extra/muxsplash "$GC_STO_THEME/MUOS/theme/active/image/$SPLASH_IMG.png"
+			fi
+
 			# Unless startup option is "last game", clear last
 			# played so we don't rerun it on the next boot.
 			if [ "$GC_GEN_STARTUP" != last ]; then
@@ -48,12 +65,20 @@ HALT_SYSTEM () {
 			fi
 			;;
 		osf)
+			# Blank screen to prevent visual glitches during halt.
+			DISPLAY_WRITE disp0 blank 1
+
 			# Always clear last played on emergency halt in case
 			# the content itself is what forced the user to reboot.
 			: >/opt/muos/config/lastplay.txt
 			;;
 		sleep)
+			# Blank screen to prevent visual glitches during halt.
+			DISPLAY_WRITE disp0 blank 1
+
+			# Close foreground process (for autosave, etc.).
 			CLOSE_CONTENT
+
 			# Only support "last game" and "resume game" startup
 			# options for RetroArch; clear last played otherwise.
 			if [ "$FG_PROC_VAL" != retroarch ]; then
@@ -62,7 +87,7 @@ HALT_SYSTEM () {
 			;;
 	esac
 
-	# When "verbose messages" setting is enabled, run the actual halt
+	# When "verbose messages" setting is enabled, run the underlying halt
 	# script in fbpad so its output is visible on screen.
 	if [ "$GC_ADV_VERBOSE" -eq 1 ]; then
 		/opt/muos/bin/fbpad /opt/muos/script/system/halt.sh "$HALT_CMD" </dev/null


### PR DESCRIPTION
[As proposed on Discord](https://discord.com/channels/1152022492001603615/1152064696308998224/1272591163613905007).

Same user-visible behavior as before when shutting down (or rebooting) from the launcher, or from sleep w/ timeout. This change only affects the "instant shutdown" sleep setting and the Power+L1+L2+R1+R2 reboot hotkey. With this change, shutdowns/reboots from those sources will blank the screen (and turn off the backlight) before beginning the halt sequence. Rationale is as follows:

* "Instant Shutdown" is currently the only one of the sleep modes that _doesn't_ immediately blank the screen when the power button is pressed. That honestly wasn't anything I gave a lot of thought to; it was more a side effect of #155. But having discussing w/ folks on the Discord a bit more, I think it makes more sense for the different "sleep" options to all behave consistently.
* The "Instant Shutdown" and OSF hotkeys can be triggered at any time, with the system in any state. We don't really know what's running, or what will run after it exits. Any number of things can try to write to the framebuffer and interact badly with the shutdown splash screen, causing visual glitches. If/when we unlock hardware overlays, it may make sense to revisit, but for now I think it's the best user experience to just blank the display in these cases.

I was able to test these changes a bit before my device started acting generally screwy, but warning this may be the last PR from me for a bit until I get my hardware issues sorted. :/