### PR TITLE
Look for PICO-8 binary/data files in BIOS dir

### DIFF
--- a/script/launch/ext-pico8.sh
+++ b/script/launch/ext-pico8.sh
@@ -15,8 +15,15 @@ SET_VAR "system" "foreground_process" "pico8_64"
 GPTOKEYB="$(GET_VAR "device" "storage/rom/mount")/MUOS/emulator/gptokeyb/gptokeyb2"
 EMUDIR="$(GET_VAR "device" "storage/rom/mount")/MUOS/emulator/pico8"
 
+# First look for emulator in BIOS directory, which allows it to follow the
+# user's storage preference. Fall back on the old path for compatibility.
+EMU="/run/muos/storage/bios/pico8/pico8_64"
+if [ ! -f "$EMU" ]; then
+	EMU="$EMUDIR/pico8_64"
+fi
+
 chmod +x "$EMUDIR"/wget
-chmod +x "$EMUDIR"/pico8_64
+chmod +x "$EMU"
 
 cd "$EMUDIR" || exit
 
@@ -26,14 +33,14 @@ if [ "$NAME" = "Splore" ]; then
 	$GPTOKEYB "./pico8_64" -c "./pico8.gptk" &
 	PATH="$EMUDIR:$PATH" \
 	HOME="$EMUDIR" \
-	./pico8_64 -windowed 0 -splore
+	"$EMU" -windowed 0 -splore
 else
 	SDL_ASSERT=always_ignore \
 	SDL_GAMECONTROLLERCONFIG=$(grep "Deeplay" "/usr/lib/gamecontrollerdb.txt") \
 	$GPTOKEYB "./pico8_64" -c "./pico8.gptk" &
 	PATH="$EMUDIR:$PATH" \
 	HOME="$EMUDIR" \
-	./pico8_64 -windowed 0 -run "$ROM"
+	"$EMU" -windowed 0 -run "$ROM"
 fi
 
 kill -9 "$(pidof pico8_64)" "$(pidof gptokeyb2)"


### PR DESCRIPTION
Technically, only `pico8.dat` is a "BIOS", whereas `pico8_64` is the actual emulator itself. However, they're both binary blobs the user needs to provide themselves for the emulation to work, so I think they're close enough in practice.

This allows the PICO-8 files to be stored on SD2 and not need to be manually restored after every reflash.

I'd also like to redirect the PICO-8 `cdata` (save RAM) and Splore ROMs to the appropriate MUOS storage directories, but that's more involved, and this was quick/easy. :)