### PR TITLE
Belt and suspenders improvements to halt script

### DIFF
--- a/script/system/halt_internal.sh
+++ b/script/system/halt_internal.sh
@@ -1,30 +1,90 @@
 #!/bin/sh
 
-# Waits 5 seconds for processes to die. The `killall5 -CONT` trick is inspired
-# by various old sysvinit scripts as a harmless way to check if any processes
-# we tried to kill are still alive.
+# Runs an external command and waits for it to finish or a timeout to expire.
+# If the timeout expires, sends SIGTERM to the program and waits a bit more
+# before sending SIGKILL if it still hasn't exited.
 #
-# Any arguments are passed along to killall5. (Use `-o PID` args to omit
-# certain processes from the existence check.)
-WAIT_FOR_DEATH() {
+# Usage: RUN_WITH_TIMEOUT TERM_SEC KILL_SEC DESCRIPTION CMD [ARG]...
+RUN_WITH_TIMEOUT() {
+	local TERM_SEC="$1" KILL_SEC="$2" DESCRIPTION="$3"
+	shift 3
+
+	printf 'Running %s...\n' "$DESCRIPTION"
+	timeout -k "$KILL_SEC" "$TERM_SEC" "$@"
+
+	local EXIT_STATUS="$?"
+	if [ "$EXIT_STATUS" -gt 128 ]; then
+		printf 'Killed %s after timeout\n' "$DESCRIPTION"
+	fi
+	return "$EXIT_STATUS"
+}
+
+# Sends the specified termination signal to every process outside the current
+# session, then waits the specified number of seconds for those processes to
+# exit. Rechecks every 250ms to see if they've all died yet.
+#
+# Usage: KILL_AND_WAIT TIMEOUT_SEC SIGNAL [-o OMIT_PID]...
+KILL_AND_WAIT() {
+	local TIMEOUT_SEC="$1" SIGNAL="$2" PROCS
+	shift 2
+
+	printf 'Sending SIG%s to processes...\n' "$SIGNAL"
+	killall5 "-$SIGNAL" "$@"
+
 	printf 'Waiting for processes to terminate: '
-	for _ in $(seq 10); do
-		# Note we sleep *before* the first check, so we always delay
-		# 500ms. This may not be strictly necessary, but seems prudent
-		# given the weird timing issues with shutdown.
-		sleep .5
-		# If killall5 didn't find any processes to signal, they must
-		# all have terminated already, and we can stop waiting.
-		if ! killall5 -CONT "$@"; then
+	for _ in $(seq "$((TIMEOUT_SEC*100/25))"); do
+		# Sleep before check since even SIGKILL isn't instant.
+		sleep .25
+		if ! PROCS="$(FIND_PROCS "$@")"; then
 			printf 'done\n'
-			return
+			return 0
 		fi
 	done
-	printf 'timed out\n'
+	printf 'timed out\nStill running: %s\n' "$PROCS"
+	return 1
+}
+
+# Prints names of commands still running outside the current session. Returns
+# success if at least one process is still running, and failure otherwise.
+#
+# Usage: FIND_PROCS [-o OMIT_PID]...
+FIND_PROCS() {
+	local EXIT_STATUS=1 PID SID COMM
+	while read -r PID SID COMM; do
+		# Skip init (PID 1), kernel threads (SID 0), and processes in
+		# the same session as the halt process.
+		if [ "$PID" -eq 1 ] || [ "$SID" -eq 0 ] || [ "$SID" -eq "$HALT_SID" ]; then
+			continue
+		fi
+		# Skip PIDs the caller tells us to. List should be short, so
+		# linear search is okay. (killall5 does the same internally.)
+		local OPT OPTARG OPTIND=1
+		while getopts o: OPT; do
+			if [ "$OPT" = o ] && [ "$PID" -eq "$OPTARG" ]; then
+				continue 2
+			fi
+		done
+		# Found a process we should've killed that is still alive.
+		if [ "$EXIT_STATUS" -eq 1 ]; then
+			EXIT_STATUS=0
+		else
+			printf ' '
+		fi
+		printf '%s' "$COMM"
+	done < <(ps -o pid=,sid=,comm=)
+	return "$EXIT_STATUS"
+}
+
+# Prints the session ID of the specified process.
+#
+# Usage: GET_SID PID
+GET_SID() {
+	cut -d ' ' -f 6 "/proc/$1/stat"
 }
 
 # Sanity check that SID = PID. (See note on setsid in halt.sh for rationale.)
-if [ "$(cut -d ' ' -f 6 /proc/self/stat)" -ne "$$" ]; then
+HALT_SID="$(GET_SID "$$")"
+if [ "$HALT_SID" -ne "$$" ]; then
 	printf 'Not a session leader (run halt.sh, not halt_internal.sh)\n' >&2
 	exit 1
 fi
@@ -40,25 +100,41 @@ fi
 HALT_CMD="$1"
 shift 1
 
-# We have to ensure we save all of the runtime variables to disk before we
-# shutdown or reboot the system as they are stored in a tmpfs location.
-printf 'Saving device variables...\n'
-/opt/muos/script/var/init/device.sh save
-printf 'Saving global variables...\n'
-/opt/muos/script/var/init/global.sh save
+{
+	# We have to ensure we save all of the runtime variables to disk before
+	# we shutdown or reboot the system as they are stored in tmpfs.
+	printf 'Saving device variables...\n'
+	/opt/muos/script/var/init/device.sh save
+	printf 'Saving global variables...\n'
+	/opt/muos/script/var/init/global.sh save
 
-# Stop system services.
-printf 'Running shutdown scripts...\n'
-/etc/init.d/rcK
+	# Sync filesystems before beginning the standard halt sequence. If a
+	# subsequent step hangs (or the user hard resets), syncing here reduces
+	# the likelihood of corrupting muOS configs, RetroArch autosaves, etc.
+	printf 'Syncing writes to disk...\n'
+	sync
 
-# Terminate other processes, giving them some time to clean up.
-printf 'Sending SIGTERM to processes...\n'
-killall5 -TERM "$@"
-WAIT_FOR_DEATH "$@"
+	# Stop system services. If shutdown scripts are still running after
+	# 10s, SIGTERM them, then wait 5s more before resorting to SIGKILL.
+	RUN_WITH_TIMEOUT 10 5 'shutdown scripts' /etc/init.d/rcK
 
-printf 'Sending SIGKILL to processes...\n'
-killall5 -KILL "$@"
-WAIT_FOR_DEATH "$@"
+	# Send SIGTERM to remaining processes. Wait up to 5s before mopping up
+	# with SIGKILL, then wait up to 1s more for everything to die.
+	if ! KILL_AND_WAIT 5 TERM "$@"; then
+		KILL_AND_WAIT 1 KILL "$@"
+	fi
+
+	# We log the steps that are likely to fail (shutdown script errors,
+	# processes that don't respond to SIGTERM, etc.), but we have to close
+	# the log file before syncing and unmounting to ensure it's written.
+	printf 'Closing log file...\n'
+} 2>&1 | tee >(ts '%Y-%m-%d %H:%M:%S' >>/opt/muos/halt.log)
+
+# Sync filesystems before unmounting them. (This should be unnecessary, but
+# sysvinit has done it since time immemorial, and the cached writes still need
+# to be flushed at some point regardless.)
+printf 'Syncing writes to disk...\n'
+sync
 
 # Disable swap. (It's not enabled by default, but just in case.)
 printf 'Disabling swap...\n'
@@ -66,10 +142,9 @@ swapoff -a
 
 # Cleanly unmount filesystems to avoid fsck/chkdsk errors.
 printf 'Unmounting filesystems...\n'
-umount -arv
+umount -ar
 
-# Actually halt/shut down/reboot the system. Note the -f so the halt command
-# only calls sync and reboot under the hood, rather than signaling init to
-# start its own buggy shutdown sequence.
+# Actually halt/shut down/reboot the system. The -f arg makes the command
+# directly run sync/reboot syscalls, not signal init to perform the halt itself.
 printf 'Going down for %s...\n' "$HALT_CMD"
-"$HALT_CMD" -f
+exec "$HALT_CMD" -f


### PR DESCRIPTION
This looks like a lot, but it's mostly a bunch of small changes that all interrelate. It spawned out of my trying to figure out what would help debug [issues like this](https://discord.com/channels/1152022492001603615/1275489174207860796), and also trying to determine how to make the halt process a little more resilient against system and user errors.

Changes (in no particular order):

* Log most of the halt process output to `/opt/muos/halt.log` so it can be debugged after the fact (example [`halt.log`](https://github.com/user-attachments/files/16735393/halt.log) file). This means we actually stand a chance of debugging problems that happen on user devices. Of course, we have to stop logging before we unmount the filesystems, or else the log isn't actually written out. :)

* Remove verbose `umount` output. It's not really needed anymore, and it clutters up the more interesting parts of the output. (We'll still get messages from `umount` on stderr if something goes wrong, e.g., if the something is keeping the rootfs busy.)

* Add a timeout around running the shutdown scripts in `/etc/init.d` so they can't hang the halt process forever. (Right now, those scripts do very little, but I can imagine us moving more cleanup there if we decide to move towards a more standard init system.)

* Replaced the cute `killall5 -SIGCONT` trick with custom code to find still-running processes (a bit ugly, but, I mean, have you ever looked at the BusyBox code? :P). This is important because it allows us to actually _print the names of the stuck processes_ when we time out, [like so](https://github.com/user-attachments/assets/1d54380c-292a-4399-8861-d16aa5737bbc). (For example, if RetroArch is hung during the shutdown, we'll now be able to see that after the fact in `halt.log`.)

* Added a `sync` call after we save the muOS config, but before any of the "real" halt sequence begins. If shutdown succeeds, this doesn't matter, but it should make us less likely to lose data written just beforehand (e.g., the configs, RetroArch autosaves, etc.) if shutdown hangs for some reason (or if the user gets bored and smacks reset).

* Added _another_ `sync` call immediately before we unmount the filesystems. I really, truly believe this isn't necessary, but I also noticed the [canonical sysvint implementation](https://github.com/slicer69/sysvinit/) does this, and probably has for decades. Do they know something we don't, or is this just ancient cargo culting? No idea, but it doesn't slow things down noticeably (those bytes are gonna be written at _some_ point either way), and it seems in line with standard practice.