### PR TITLE
Log CLOSE_CONTENT on sleep and copy halt.log to SD1 on startup

### DIFF
--- a/script/mux/close_game.sh
+++ b/script/mux/close_game.sh
@@ -8,15 +8,18 @@ CLOSE_CONTENT() {
 	FG_PROC_VAL=$(GET_VAR "system" "foreground_process")
 	FG_PROC_PID="$(pidof "$FG_PROC_VAL")"
 	if [ -n "$FG_PROC_PID" ]; then
+		printf 'Closing foreground content (%s): ' "$FG_PROC_VAL"
 		kill -CONT "$FG_PROC_PID" 2>/dev/null
 		kill "$FG_PROC_PID" 2>/dev/null
 		for _ in $(seq 1 20); do
 			if ! kill -0 "$FG_PROC_PID" 2>/dev/null; then
-				break
+				printf 'done\n'
+				return
 			fi
 			sleep .25
 		done
 	fi
+	printf 'timed out\n'
 }
 
 # Cleanly halts, shuts down, or reboots the device.
@@ -33,53 +36,58 @@ HALT_SYSTEM() {
 	HALT_SRC="$1"
 	HALT_CMD="$2"
 
-	case "$HALT_CMD" in
-		halt | poweroff) SPLASH_IMG=shutdown ;;
-		reboot) SPLASH_IMG=reboot ;;
-	esac
+	{
+		printf 'Halting system (source %s, command %s)\n' "$HALT_SRC" "$HALT_CMD"
 
-	# Turn on power LED for consistency across different halt codepaths.
-	echo 1 >"$(GET_VAR "device" "board/led")"
+		case "$HALT_CMD" in
+			halt | poweroff) SPLASH_IMG=shutdown ;;
+			reboot) SPLASH_IMG=reboot ;;
+		esac
 
-	# Clear state we never want to persist across reboots.
-	: >/opt/muos/config/address.txt
+		# Turn on power LED for visual feedback on halt success.
+		echo 1 >"$(GET_VAR "device" "board/led")"
 
-	case "$HALT_SRC" in
-		frontend)
-			# When not showing verbose output, display a
-			# theme-provided splash screen during shutdown.
-			if [ "$(GET_VAR "global" "settings/advanced/verbose")" -eq 0 ]; then
-				/opt/muos/extra/muxsplash "/run/muos/storage/theme/active/image/$SPLASH_IMG.png"
-			fi
+		# Clear state we never want to persist across reboots.
+		: >/opt/muos/config/address.txt
 
-			# Unless startup option is "last game", clear last
-			# played so we don't rerun it on the next boot.
-			if [ "$(GET_VAR "global" "settings/general/startup")" != last ]; then
+		case "$HALT_SRC" in
+			frontend)
+				# When not showing verbose output, display a
+				# theme-provided splash screen during shutdown.
+				if [ "$(GET_VAR "global" "settings/advanced/verbose")" -eq 0 ]; then
+					/opt/muos/extra/muxsplash "/run/muos/storage/theme/active/image/$SPLASH_IMG.png"
+				fi
+
+				# Unless startup option is "last game", clear
+				# last played so we don't rerun it on boot.
+				if [ "$(GET_VAR "global" "settings/general/startup")" != last ]; then
+					: >/opt/muos/config/lastplay.txt
+				fi
+				;;
+			osf)
+				# Blank screen to prevent visual glitches.
+				DISPLAY_WRITE disp0 blank 1
+
+				# Clear last played on reboot hotkey in case
+				# the content itself forced the user to reboot.
 				: >/opt/muos/config/lastplay.txt
-			fi
-			;;
-		osf)
-			# Blank screen to prevent visual glitches during halt.
-			DISPLAY_WRITE disp0 blank 1
+				;;
+			sleep)
+				# Blank screen to prevent visual glitches.
+				DISPLAY_WRITE disp0 blank 1
 
-			# Always clear last played on emergency halt in case
-			# the content itself is what forced the user to reboot.
-			: >/opt/muos/config/lastplay.txt
-			;;
-		sleep)
-			# Blank screen to prevent visual glitches during halt.
-			DISPLAY_WRITE disp0 blank 1
+				# Close foreground process (for autosave).
+				CLOSE_CONTENT
 
-			# Close foreground process (for autosave, etc.).
-			CLOSE_CONTENT
-
-			# Only support "last game" and "resume game" startup
-			# options for RetroArch; clear last played otherwise.
-			if [ "$FG_PROC_VAL" != retroarch ]; then
-				: >/opt/muos/config/lastplay.txt
-			fi
-			;;
-	esac
+				# Only support "last game" and "resume game"
+				# startup options for RetroArch; clear last
+				# played otherwise.
+				if [ "$FG_PROC_VAL" != retroarch ]; then
+					: >/opt/muos/config/lastplay.txt
+				fi
+				;;
+		esac
+	} 2>&1 | ts '%Y-%m-%d %H:%M:%S' >>/opt/muos/halt.log
 
 	# When "verbose messages" setting is enabled, run the underlying halt
 	# script in fbpad so its output is visible on screen.

--- a/script/system/startup.sh
+++ b/script/system/startup.sh
@@ -149,7 +149,7 @@ chmod -R 755 /opt &
 
 echo 2 >/proc/sys/abi/cp15_barrier &
 
-cp "/opt/muos/boot.log" "$(GET_VAR "device" "storage/rom/mount")/MUOS/log/boot/."
+cp /opt/muos/*.log "$(GET_VAR "device" "storage/rom/mount")/MUOS/log/boot/."
 
 LOGGER "$0" "BOOTING" "Setting current variable modes"
 GET_VAR "global" "settings/advanced/android" >/tmp/mux_adb_mode


### PR DESCRIPTION
Quick followup on the new logging added in #165. Now we'll log the `CLOSE_CONTENT` results to `halt.log` as well, which should help debug RetroArch hang/autosave issues in the future.

Example failure logging (I intentionally sent `SIGSTOP` to `pipewire` in a loop to trigger that particular hang):

```
2024-08-24 17:15:18 Halting system (source sleep, command poweroff)
2024-08-24 17:15:24 Closing foreground content (retroarch): timed out
2024-08-24 17:15:24 Saving device variables...
2024-08-24 17:15:25 Saving global variables...
2024-08-24 17:15:25 Syncing writes to disk...
2024-08-24 17:15:25 Running shutdown scripts...
2024-08-24 17:15:25 Stopping system message bus: done
2024-08-24 17:15:25 Stopping haveged: OK
2024-08-24 17:15:25 Sending SIGTERM to processes...
2024-08-24 17:15:26 Waiting for processes to terminate: done
2024-08-24 17:15:26 Closing log file...
```

Compare to a log for a successful `CLOSE_CONTENT` and shutdown:

```
2024-08-24 17:19:08 Halting system (source sleep, command poweroff)
2024-08-24 17:19:10 Closing foreground content (retroarch): done
2024-08-24 17:19:10 Saving device variables...
2024-08-24 17:19:10 Saving global variables...
2024-08-24 17:19:11 Syncing writes to disk...
2024-08-24 17:19:11 Running shutdown scripts...
2024-08-24 17:19:11 Stopping system message bus: done
2024-08-24 17:19:11 Stopping haveged: OK
2024-08-24 17:19:11 Sending SIGTERM to processes...
2024-08-24 17:19:12 Waiting for processes to terminate: done
2024-08-24 17:19:12 Closing log file...
```

I also updated the startup script to copy `halt.log` to `/mnt/mmc/MUOS/log/boot/halt.log`, where `boot.log` is copied. (This might make it easier for users to find the halt file if we need to ask for it. I assume that's why `boot.log` is already copied there?)

Additionally, I cleaned up some excessively long comments and code in the halt scripts. No functional changes there, just fixing my crap coding from late last night. :P