### PR TITLE
Show splash screen for reboot after factory reset

### DIFF
--- a/script/system/startup.sh
+++ b/script/system/startup.sh
@@ -112,7 +112,8 @@ if [ "$(GET_VAR "global" "boot/factory_reset")" -eq 1 ]; then
 	/opt/muos/extra/muxcredits
 	killall -q "mpg123"
 
-	/opt/muos/script/system/halt.sh reboot
+	. /opt/muos/script/mux/close_game.sh
+	HALT_SYSTEM frontend reboot
 fi
 
 LOGGER "$0" "BOOTING" "Checking for passcode lock"


### PR DESCRIPTION
I think this may have worked for a day or two, but I probably broke it during the various halt changes lately. And didn't notice till I went to flash a new test image today.

Longer term I think it would make sense for `close_game.sh` to be a script that's _executed_ rather than _sourced_. (We used to rely on sourcing it so it could set a variable in the same shell as the caller, but now all that logic is contained inside `close_game.sh`.) Probably also want to rename it to not say "game" since as you noted, not everything we run is a game.

But I'd rather do the quick fix now and look into the other change in a separate PR because there's a number of different places that script is referenced.