### PR TITLE
Shut down 10s after mount failure

### DIFF
--- a/script/var/func.sh
+++ b/script/var/func.sh
@@ -67,10 +67,12 @@ LOGGER() {
 
 DEVICE_MOUNT_FAILURE() {
 	/opt/muos/extra/muxstart "$(printf "Critical Mount Failure\n\nFailed to mount '%s'!\n\n%s" "$1" "$2")"
-	sleep infinity
+	sleep 10
+	/opt/muos/script/system/halt.sh poweroff
 }
 
 DIRECTORY_MOUNT_FAILURE() {
 	/opt/muos/extra/muxstart "$(printf "Critical Mount Failure\n\nFailed to mount '%s' on '%s'!" "$1" "$2")"
-	sleep infinity
+	sleep 10
+	/opt/muos/script/system/halt.sh poweroff
 }


### PR DESCRIPTION
I know you were talking about making this fancier, with e.g. "press start to continue or power to shut down", or some such. This is just a quick fix in the meantime if you want it. (Right now, the only way to get out of the mount failure screen that I could find is to hard power off, and an auto shutdown after some time to read the text seemed a little safer.)