### PR TITLE
Bind mount PPSSPP save files/states into MUOS/save

### DIFF
--- a/script/var/init/storage.sh
+++ b/script/var/init/storage.sh
@@ -54,3 +54,16 @@ for S_VAR in $STORAGE_VARS; do
 
 	S_=$((S_ + 1))
 done
+
+# Bind hardcoded paths on SD1's ROM parition (where we can't use symlinks) to
+# subdirs of the appropriate locations under /run/muos/storage (bound above).
+BIND_INTO_STORAGE() {
+	local TARGET="/run/muos/storage/$1" MOUNT="$(GET_VAR "device" "storage/rom/mount")/MUOS/$2"
+	mkdir -p "$TARGET" "$MOUNT"
+	if ! mount --bind "$TARGET" "$MOUNT"; then
+		CRITICAL_FAILURE directory "$TARGET" "$MOUNT"
+	fi
+}
+
+BIND_INTO_STORAGE save/state/PPSSPP-Ext emulator/ppsspp/.config/ppsspp/PSP/PPSSPP_STATE
+BIND_INTO_STORAGE save/file/PPSSPP-Ext emulator/ppsspp/.config/ppsspp/PSP/SAVEDATA


### PR DESCRIPTION
It's late and this is tested minimally, but it seems to work, with save files and states for external PPSSPP both ending up on SD2 according to my storage preference.

Choosing paths under `MUOS/save` is hard and [as discussed on Discord](https://discord.com/channels/1152022492001603615/1161936003477536788/1277850341446254634), existing external emulators are already kind of inconsistent.

For now, I went with

* `/mnt/mmc/MUOS/emulator/ppsspp/.config/ppsspp/PSP/SAVEDATA` -> `/run/muos/save/file/PPSSPP-Ext`
* `/mnt/mmc/MUOS/emulator/ppsspp/.config/ppsspp/PSP/PPSSPP_STATE` -> `/run/muos/save/state/PPSSPP-Ext`

This is consistent with what was done for ScummVM (which writes save data to `/run/muos/storage/save/file/ScummVM-Ext`, and it should avoid name conflicts with the RetroArch internal PPSSPP core in case anyone is using that. But I am not super attached to the naming and would be happy to change it.

Also, this should still work fine when restoring existing save data backups after people upgrade from Baked Beans to Banana. When they unzip the backup, it will extract into the old path, which the bind mount will correctly redirect to the new one. (However, we may want to delete the old backs from the script that _creates_ the save backups, or else we'll back up the PPSSPP saves twice in new zips going forward.)