### PR TITLE
Fix "last game" inconsistency between shutting down from launcher vs sleep

### DIFF
--- a/script/mux/close_game.sh
+++ b/script/mux/close_game.sh
@@ -78,13 +78,6 @@ HALT_SYSTEM() {
 
 				# Close foreground process (for autosave).
 				CLOSE_CONTENT
-
-				# Only support "last game" and "resume game"
-				# startup options for RetroArch; clear last
-				# played otherwise.
-				if [ "$FG_PROC_VAL" != retroarch ]; then
-					: >/opt/muos/config/lastplay.txt
-				fi
 				;;
 		esac
 	} 2>&1 | ts '%Y-%m-%d %H:%M:%S' >>/opt/muos/halt.log


### PR DESCRIPTION
When the startup preference is set to "Last Game", we currently handle non-RA emulators differently depending on how the device is shut down;

* When shutting down from the launcher, we re-launch the game on next boot whether it's an RA game or not.
* When shutting down from sleep, if the last game was a non-RA game, then we clear it so it doesn't relaunch on next boot.

I carried this behavior over in previous changes, but wanted to revisit since I feel like we should be consistent one way or the other. Personally, I think we should just remove the RA special case and always relaunch the last game, especially since we now rely on the emulators themselves to support autoloading save states. (Right now that's just RA, but others like PPSSPP [might in the future](https://github.com/hrydgard/ppsspp/issues/8661).)