### PR TITLE
Speed up muOS boot via background mounts, etc.

### DIFF
--- a/device/rg28xx/script/charge.sh
+++ b/device/rg28xx/script/charge.sh
@@ -14,4 +14,6 @@ if [ "$(cat "$(GET_VAR "device" "battery/charger")")" -eq 1 ] && [ "$(GET_VAR "g
 	if ! /opt/muos/extra/muxcharge; then
 		/opt/muos/script/system/halt.sh poweroff
 	fi
+
+	echo "performance" >"$(GET_VAR "device" "cpu/governor")"
 fi

--- a/device/rg28xx/script/start.sh
+++ b/device/rg28xx/script/start.sh
@@ -6,21 +6,6 @@ sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.con
 
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/script/module.sh &
 
-if mount -t "$(GET_VAR "device" "storage/boot/type")" -o rw,utf8,noatime,nofail \
-	/dev/"$(GET_VAR "device" "storage/boot/dev")$(GET_VAR "device" "storage/boot/sep")$(GET_VAR "device" "storage/boot/num")" \
-	"$(GET_VAR "device" "storage/boot/mount")"; then
-	SET_VAR "device" "storage/boot/active" "1"
-fi
-
-if mount -t "$(GET_VAR "device" "storage/rom/type")" -o rw,utf8,noatime,nofail \
-	/dev/"$(GET_VAR "device" "storage/rom/dev")$(GET_VAR "device" "storage/rom/sep")$(GET_VAR "device" "storage/rom/num")" \
-	"$(GET_VAR "device" "storage/rom/mount")"; then
-	SET_VAR "device" "storage/rom/active" "1"
-fi
-
-# Bind mount storage preference to /run/muos
-/opt/muos/script/var/init/storage.sh
-
 if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 	mount -t debugfs debugfs /sys/kernel/debug
 fi

--- a/device/rg35xx-2024/script/charge.sh
+++ b/device/rg35xx-2024/script/charge.sh
@@ -14,4 +14,6 @@ if [ "$(cat "$(GET_VAR "device" "battery/charger")")" -eq 1 ] && [ "$(GET_VAR "g
 	if ! /opt/muos/extra/muxcharge; then
 		/opt/muos/script/system/halt.sh poweroff
 	fi
+
+	echo "performance" >"$(GET_VAR "device" "cpu/governor")"
 fi

--- a/device/rg35xx-2024/script/start.sh
+++ b/device/rg35xx-2024/script/start.sh
@@ -6,21 +6,6 @@ sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.con
 
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/script/module.sh &
 
-if mount -t "$(GET_VAR "device" "storage/boot/type")" -o rw,utf8,noatime,nofail \
-	/dev/"$(GET_VAR "device" "storage/boot/dev")$(GET_VAR "device" "storage/boot/sep")$(GET_VAR "device" "storage/boot/num")" \
-	"$(GET_VAR "device" "storage/boot/mount")"; then
-	SET_VAR "device" "storage/boot/active" "1"
-fi
-
-if mount -t "$(GET_VAR "device" "storage/rom/type")" -o rw,utf8,noatime,nofail \
-	/dev/"$(GET_VAR "device" "storage/rom/dev")$(GET_VAR "device" "storage/rom/sep")$(GET_VAR "device" "storage/rom/num")" \
-	"$(GET_VAR "device" "storage/rom/mount")"; then
-	SET_VAR "device" "storage/rom/active" "1"
-fi
-
-# Bind mount storage preference to /run/muos
-/opt/muos/script/var/init/storage.sh
-
 if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 	mount -t debugfs debugfs /sys/kernel/debug
 fi

--- a/device/rg35xx-h/script/charge.sh
+++ b/device/rg35xx-h/script/charge.sh
@@ -14,4 +14,6 @@ if [ "$(cat "$(GET_VAR "device" "battery/charger")")" -eq 1 ] && [ "$(GET_VAR "g
 	if ! /opt/muos/extra/muxcharge; then
 		/opt/muos/script/system/halt.sh poweroff
 	fi
+
+	echo "performance" >"$(GET_VAR "device" "cpu/governor")"
 fi

--- a/device/rg35xx-h/script/start.sh
+++ b/device/rg35xx-h/script/start.sh
@@ -6,21 +6,6 @@ sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.con
 
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/script/module.sh &
 
-if mount -t "$(GET_VAR "device" "storage/boot/type")" -o rw,utf8,noatime,nofail \
-	/dev/"$(GET_VAR "device" "storage/boot/dev")$(GET_VAR "device" "storage/boot/sep")$(GET_VAR "device" "storage/boot/num")" \
-	"$(GET_VAR "device" "storage/boot/mount")"; then
-	SET_VAR "device" "storage/boot/active" "1"
-fi
-
-if mount -t "$(GET_VAR "device" "storage/rom/type")" -o rw,utf8,noatime,nofail \
-	/dev/"$(GET_VAR "device" "storage/rom/dev")$(GET_VAR "device" "storage/rom/sep")$(GET_VAR "device" "storage/rom/num")" \
-	"$(GET_VAR "device" "storage/rom/mount")"; then
-	SET_VAR "device" "storage/rom/active" "1"
-fi
-
-# Bind mount storage preference to /run/muos
-/opt/muos/script/var/init/storage.sh
-
 if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 	mount -t debugfs debugfs /sys/kernel/debug
 fi

--- a/device/rg35xx-plus/script/charge.sh
+++ b/device/rg35xx-plus/script/charge.sh
@@ -14,4 +14,6 @@ if [ "$(cat "$(GET_VAR "device" "battery/charger")")" -eq 1 ] && [ "$(GET_VAR "g
 	if ! /opt/muos/extra/muxcharge; then
 		/opt/muos/script/system/halt.sh poweroff
 	fi
+
+	echo "performance" >"$(GET_VAR "device" "cpu/governor")"
 fi

--- a/device/rg35xx-plus/script/start.sh
+++ b/device/rg35xx-plus/script/start.sh
@@ -6,21 +6,6 @@ sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.con
 
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/script/module.sh &
 
-if mount -t "$(GET_VAR "device" "storage/boot/type")" -o rw,utf8,noatime,nofail \
-	/dev/"$(GET_VAR "device" "storage/boot/dev")$(GET_VAR "device" "storage/boot/sep")$(GET_VAR "device" "storage/boot/num")" \
-	"$(GET_VAR "device" "storage/boot/mount")"; then
-	SET_VAR "device" "storage/boot/active" "1"
-fi
-
-if mount -t "$(GET_VAR "device" "storage/rom/type")" -o rw,utf8,noatime,nofail \
-	/dev/"$(GET_VAR "device" "storage/rom/dev")$(GET_VAR "device" "storage/rom/sep")$(GET_VAR "device" "storage/rom/num")" \
-	"$(GET_VAR "device" "storage/rom/mount")"; then
-	SET_VAR "device" "storage/rom/active" "1"
-fi
-
-# Bind mount storage preference to /run/muos
-/opt/muos/script/var/init/storage.sh
-
 if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 	mount -t debugfs debugfs /sys/kernel/debug
 fi

--- a/device/rg35xx-sp/script/charge.sh
+++ b/device/rg35xx-sp/script/charge.sh
@@ -14,4 +14,6 @@ if [ "$(cat "$(GET_VAR "device" "battery/charger")")" -eq 1 ] && [ "$(GET_VAR "g
 	if ! /opt/muos/extra/muxcharge; then
 		/opt/muos/script/system/halt.sh poweroff
 	fi
+
+	echo "performance" >"$(GET_VAR "device" "cpu/governor")"
 fi

--- a/device/rg35xx-sp/script/start.sh
+++ b/device/rg35xx-sp/script/start.sh
@@ -12,21 +12,6 @@ sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.con
 
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/script/module.sh &
 
-if mount -t "$(GET_VAR "device" "storage/boot/type")" -o rw,utf8,noatime,nofail \
-	/dev/"$(GET_VAR "device" "storage/boot/dev")$(GET_VAR "device" "storage/boot/sep")$(GET_VAR "device" "storage/boot/num")" \
-	"$(GET_VAR "device" "storage/boot/mount")"; then
-	SET_VAR "device" "storage/boot/active" "1"
-fi
-
-if mount -t "$(GET_VAR "device" "storage/rom/type")" -o rw,utf8,noatime,nofail \
-	/dev/"$(GET_VAR "device" "storage/rom/dev")$(GET_VAR "device" "storage/rom/sep")$(GET_VAR "device" "storage/rom/num")" \
-	"$(GET_VAR "device" "storage/rom/mount")"; then
-	SET_VAR "device" "storage/rom/active" "1"
-fi
-
-# Bind mount storage preference to /run/muos
-/opt/muos/script/var/init/storage.sh
-
 if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 	mount -t debugfs debugfs /sys/kernel/debug
 fi

--- a/device/rg40xx-h/script/charge.sh
+++ b/device/rg40xx-h/script/charge.sh
@@ -15,4 +15,6 @@ if [ "$(cat "$(GET_VAR "device" "battery/charger")")" -eq 1 ] && [ "$(GET_VAR "g
 	if ! /opt/muos/extra/muxcharge; then
 		/opt/muos/script/system/halt.sh poweroff
 	fi
+
+	echo "performance" >"$(GET_VAR "device" "cpu/governor")"
 fi

--- a/device/rg40xx-h/script/start.sh
+++ b/device/rg40xx-h/script/start.sh
@@ -6,21 +6,6 @@ sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.con
 
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/script/module.sh &
 
-if mount -t "$(GET_VAR "device" "storage/boot/type")" -o rw,utf8,noatime,nofail \
-	/dev/"$(GET_VAR "device" "storage/boot/dev")$(GET_VAR "device" "storage/boot/sep")$(GET_VAR "device" "storage/boot/num")" \
-	"$(GET_VAR "device" "storage/boot/mount")"; then
-	SET_VAR "device" "storage/boot/active" "1"
-fi
-
-if mount -t "$(GET_VAR "device" "storage/rom/type")" -o rw,utf8,noatime,nofail \
-	/dev/"$(GET_VAR "device" "storage/rom/dev")$(GET_VAR "device" "storage/rom/sep")$(GET_VAR "device" "storage/rom/num")" \
-	"$(GET_VAR "device" "storage/rom/mount")"; then
-	SET_VAR "device" "storage/rom/active" "1"
-fi
-
-# Bind mount storage preference to /run/muos
-/opt/muos/script/var/init/storage.sh
-
 if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 	mount -t debugfs debugfs /sys/kernel/debug
 fi

--- a/device/rg40xx-v/script/charge.sh
+++ b/device/rg40xx-v/script/charge.sh
@@ -15,4 +15,6 @@ if [ "$(cat "$(GET_VAR "device" "battery/charger")")" -eq 1 ] && [ "$(GET_VAR "g
 	if ! /opt/muos/extra/muxcharge; then
 		/opt/muos/script/system/halt.sh poweroff
 	fi
+
+	echo "performance" >"$(GET_VAR "device" "cpu/governor")"
 fi

--- a/device/rg40xx-v/script/start.sh
+++ b/device/rg40xx-v/script/start.sh
@@ -6,21 +6,6 @@ sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.con
 
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/script/module.sh &
 
-if mount -t "$(GET_VAR "device" "storage/boot/type")" -o rw,utf8,noatime,nofail \
-	/dev/"$(GET_VAR "device" "storage/boot/dev")$(GET_VAR "device" "storage/boot/sep")$(GET_VAR "device" "storage/boot/num")" \
-	"$(GET_VAR "device" "storage/boot/mount")"; then
-	SET_VAR "device" "storage/boot/active" "1"
-fi
-
-if mount -t "$(GET_VAR "device" "storage/rom/type")" -o rw,utf8,noatime,nofail \
-	/dev/"$(GET_VAR "device" "storage/rom/dev")$(GET_VAR "device" "storage/rom/sep")$(GET_VAR "device" "storage/rom/num")" \
-	"$(GET_VAR "device" "storage/rom/mount")"; then
-	SET_VAR "device" "storage/rom/active" "1"
-fi
-
-# Bind mount storage preference to /run/muos
-/opt/muos/script/var/init/storage.sh
-
 if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 	mount -t debugfs debugfs /sys/kernel/debug
 fi

--- a/script/mount/boot.sh
+++ b/script/mount/boot.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+. /opt/muos/script/var/func.sh
+
+if mount -t "$(GET_VAR "device" "storage/boot/type")" -o rw,utf8,noatime,nofail \
+	/dev/"$(GET_VAR "device" "storage/boot/dev")$(GET_VAR "device" "storage/boot/sep")$(GET_VAR "device" "storage/boot/num")" \
+	"$(GET_VAR "device" "storage/boot/mount")"; then
+	SET_VAR "device" "storage/boot/active" "1"
+fi

--- a/script/mount/mmc.sh
+++ b/script/mount/mmc.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+. /opt/muos/script/var/func.sh
+
+if mount -t "$(GET_VAR "device" "storage/rom/type")" -o rw,utf8,noatime,nofail \
+	/dev/"$(GET_VAR "device" "storage/rom/dev")$(GET_VAR "device" "storage/rom/sep")$(GET_VAR "device" "storage/rom/num")" \
+	"$(GET_VAR "device" "storage/rom/mount")"; then
+	SET_VAR "device" "storage/rom/active" "1"
+fi

--- a/script/mount/sdcard.sh
+++ b/script/mount/sdcard.sh
@@ -2,53 +2,54 @@
 
 . /opt/muos/script/var/func.sh
 
-STORE_DEVICE=$(GET_VAR "device" "storage/sdcard/dev")$(GET_VAR "device" "storage/sdcard/sep")$(GET_VAR "device" "storage/sdcard/num")
+DEVICE="$(GET_VAR "device" "storage/sdcard/dev")$(GET_VAR "device" "storage/sdcard/sep")$(GET_VAR "device" "storage/sdcard/num")"
+MOUNT="$(GET_VAR "device" "storage/sdcard/mount")"
 MOUNTED=false
 
-mkdir "$(GET_VAR "device" "storage/sdcard/mount")"
+mkdir -p "$MOUNT"
 
+HAS_DEVICE() {
+	grep -q "$DEVICE" /proc/partitions
+}
+
+MOUNT_DEVICE() {
+	FS_TYPE="$(blkid -o value -s TYPE "/dev/$DEVICE")"
+
+	BLK_ID4=""
+	for D in /sys/devices/platform/soc/sdc0/mmc_host/mmc0/mmc0:*; do
+		[ -d "$D" ] && BLK_ID4="${D##*/}" && break
+	done
+
+	case "$FS_TYPE" in
+		vfat|exfat) FS_OPTS=rw,utf8,noatime,nofail ;;
+		ext4) FS_OPTS=defaults,noatime,nofail ;;
+		*) return ;;
+	esac
+
+	if mount -t "$FS_TYPE" -o "$FS_OPTS" "/dev/$DEVICE" "$MOUNT"; then
+		SET_VAR "device" "storage/sdcard/active" "1"
+		echo noop >/sys/devices/platform/soc/sdc2/mmc_host/mmc1/mmc1:"$BLK_ID4"/block/mmcblk1/queue/scheduler
+		echo on >/sys/devices/platform/soc/sdc2/mmc_host/mmc1/power/control
+		MOUNTED=true
+	fi
+}
+
+# Synchronously mount SD card (if media is inserted) so it's available as a
+# target of bind mounts under /run/muos/storage as soon as this script returns.
+HAS_DEVICE && MOUNT_DEVICE
+
+# Asynchronously monitor insertion/eject, adjusting storage mounts as needed.
 while true; do
-	if grep -m 1 "$STORE_DEVICE" /proc/partitions >/dev/null; then
+	sleep 2
+	if HAS_DEVICE; then
 		if ! $MOUNTED; then
-			FS_TYPE=$(blkid -o value -s TYPE "/dev/$STORE_DEVICE")
-
-			BLK_ID4=""
-			for D in /sys/devices/platform/soc/sdc0/mmc_host/mmc0/mmc0:*; do
-				[ -d "$D" ] && BLK_ID4="${D##*/}" && break
-			done
-
-			if [ "$FS_TYPE" = "vfat" ]; then
-				if mount -t vfat -o rw,utf8,noatime,nofail "/dev/$STORE_DEVICE" "$(GET_VAR "device" "storage/sdcard/mount")"; then
-					SET_VAR "device" "storage/sdcard/active" "1"
-					echo noop >/sys/devices/platform/soc/sdc2/mmc_host/mmc1/mmc1:"$BLK_ID4"/block/mmcblk1/queue/scheduler
-					echo on >/sys/devices/platform/soc/sdc2/mmc_host/mmc1/power/control
-					MOUNTED=true
-				fi
-			elif [ "$FS_TYPE" = "exfat" ]; then
-				if mount -t exfat -o rw,utf8,noatime,nofail "/dev/$STORE_DEVICE" "$(GET_VAR "device" "storage/sdcard/mount")"; then
-					SET_VAR "device" "storage/sdcard/active" "1"
-					echo noop >/sys/devices/platform/soc/sdc2/mmc_host/mmc1/mmc1:"$BLK_ID4"/block/mmcblk1/queue/scheduler
-					echo on >/sys/devices/platform/soc/sdc2/mmc_host/mmc1/power/control
-					MOUNTED=true
-				fi
-			elif [ "$FS_TYPE" = "ext4" ]; then
-				if mount -t ext4 -o defaults,noatime,nofail "/dev/$STORE_DEVICE" "$(GET_VAR "device" "storage/sdcard/mount")"; then
-					SET_VAR "device" "storage/sdcard/active" "1"
-					echo noop >/sys/devices/platform/soc/sdc2/mmc_host/mmc1/mmc1:"$BLK_ID4"/block/mmcblk1/queue/scheduler
-					echo on >/sys/devices/platform/soc/sdc2/mmc_host/mmc1/power/control
-					MOUNTED=true
-				fi
-			fi
+			MOUNT_DEVICE
+			/opt/muos/script/var/init/storage.sh
 		fi
 	elif $MOUNTED; then
 		umount "$(GET_VAR "device" "storage/sdcard/mount")"
-		STORAGE_LOCS="bios info/catalogue info/config info/core info/favourite info/history music save screenshot theme"
-		for S_LOC in $STORAGE_LOCS; do
-			umount "/run/muos/storage/$S_LOC"
-		done
 		/opt/muos/script/var/init/storage.sh
 		SET_VAR "device" "storage/sdcard/active" "0"
 		MOUNTED=false
 	fi
-	sleep 2
 done &

--- a/script/mount/start.sh
+++ b/script/mount/start.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Mount partitions needed for bind mounts in parallel.
+#
+# These scripts return as soon as the necessary mounts are available, but they
+# can also leave extra background jobs running that respond to future media
+# add/remove events.
+/opt/muos/script/mount/mmc.sh &
+/opt/muos/script/mount/sdcard.sh &
+wait
+
+# Initialize bind mounts under /run/muos/storage.
+/opt/muos/script/var/init/storage.sh
+
+# Mount boot partition and start watching for USB storage. These aren't needed
+# by the rest of the boot process, so handle them after bind mounts are set up.
+/opt/muos/script/mount/boot.sh &
+/opt/muos/script/mount/usb.sh &

--- a/script/mux/frontend.sh
+++ b/script/mux/frontend.sh
@@ -85,6 +85,8 @@ fi
 /opt/muos/script/mux/golden.sh &
 
 LOGGER "$0" "FRONTEND" "Starting frontend launcher"
+cp /opt/muos/*.log "$(GET_VAR "device" "storage/rom/mount")/MUOS/log/boot/." &
+
 while true; do
 	# Background Music
 	if [ "$(GET_VAR "global" "settings/general/bgm")" -eq 1 ]; then

--- a/script/mux/frontend.sh
+++ b/script/mux/frontend.sh
@@ -84,6 +84,13 @@ fi
 
 /opt/muos/script/mux/golden.sh &
 
+LOGGER "$0" "FRONTEND" "Setting default CPU governor"
+GET_VAR "device" "cpu/default" >"$(GET_VAR "device" "cpu/governor")"
+GET_VAR "device" "cpu/sampling_rate_default" >"$(GET_VAR "device" "cpu/sampling_rate")"
+GET_VAR "device" "cpu/up_threshold_default" >"$(GET_VAR "device" "cpu/up_threshold")"
+GET_VAR "device" "cpu/sampling_down_factor_default" >"$(GET_VAR "device" "cpu/sampling_down_factor")"
+GET_VAR "device" "cpu/io_is_busy_default" >"$(GET_VAR "device" "cpu/io_is_busy")"
+
 LOGGER "$0" "FRONTEND" "Starting frontend launcher"
 cp /opt/muos/*.log "$(GET_VAR "device" "storage/rom/mount")/MUOS/log/boot/." &
 

--- a/script/mux/frontend.sh
+++ b/script/mux/frontend.sh
@@ -29,14 +29,6 @@ KILL_BGM() {
 	fi
 }
 
-LOGGER "$0" "FRONTEND" "Waiting for mount: $(GET_VAR "device" "storage/rom/mount")"
-while true; do
-	if mount | grep -q "$(GET_VAR "device" "storage/rom/mount")"; then
-		break
-	fi
-	sleep 0.25
-done
-
 if [ "$(GET_VAR "global" "settings/advanced/random_theme")" -eq 1 ]; then
 	LOGGER "$0" "FRONTEND" "Changing to a random theme"
 	/opt/muos/script/mux/theme.sh "?R"

--- a/script/mux/frontend.sh
+++ b/script/mux/frontend.sh
@@ -36,6 +36,13 @@ fi
 
 LAST_PLAY="/opt/muos/config/lastplay.txt"
 
+LOGGER "$0" "FRONTEND" "Setting default CPU governor"
+GET_VAR "device" "cpu/default" >"$(GET_VAR "device" "cpu/governor")"
+GET_VAR "device" "cpu/sampling_rate_default" >"$(GET_VAR "device" "cpu/sampling_rate")"
+GET_VAR "device" "cpu/up_threshold_default" >"$(GET_VAR "device" "cpu/up_threshold")"
+GET_VAR "device" "cpu/sampling_down_factor_default" >"$(GET_VAR "device" "cpu/sampling_down_factor")"
+GET_VAR "device" "cpu/io_is_busy_default" >"$(GET_VAR "device" "cpu/io_is_busy")"
+
 LOGGER "$0" "FRONTEND" "Checking for last or resume startup"
 if [ "$(GET_VAR "global" "settings/general/startup")" = "last" ] || [ "$(GET_VAR "global" "settings/general/startup")" = "resume" ]; then
 	if [ -s "$LAST_PLAY" ]; then
@@ -75,13 +82,6 @@ if [ "$(GET_VAR "global" "settings/general/startup")" = "last" ] || [ "$(GET_VAR
 fi
 
 /opt/muos/script/mux/golden.sh &
-
-LOGGER "$0" "FRONTEND" "Setting default CPU governor"
-GET_VAR "device" "cpu/default" >"$(GET_VAR "device" "cpu/governor")"
-GET_VAR "device" "cpu/sampling_rate_default" >"$(GET_VAR "device" "cpu/sampling_rate")"
-GET_VAR "device" "cpu/up_threshold_default" >"$(GET_VAR "device" "cpu/up_threshold")"
-GET_VAR "device" "cpu/sampling_down_factor_default" >"$(GET_VAR "device" "cpu/sampling_down_factor")"
-GET_VAR "device" "cpu/io_is_busy_default" >"$(GET_VAR "device" "cpu/io_is_busy")"
 
 LOGGER "$0" "FRONTEND" "Starting frontend launcher"
 cp /opt/muos/*.log "$(GET_VAR "device" "storage/rom/mount")/MUOS/log/boot/." &

--- a/script/system/startup.sh
+++ b/script/system/startup.sh
@@ -157,8 +157,6 @@ chmod -R 755 /opt &
 
 echo 2 >/proc/sys/abi/cp15_barrier &
 
-cp /opt/muos/*.log "$(GET_VAR "device" "storage/rom/mount")/MUOS/log/boot/." &
-
 LOGGER "$0" "BOOTING" "Backing up global configuration"
 /opt/muos/script/system/config_backup.sh &
 

--- a/script/system/startup.sh
+++ b/script/system/startup.sh
@@ -108,13 +108,6 @@ LOGGER "$0" "BOOTING" "Running Device Specifics"
 LOGGER "$0" "BOOTING" "Detecting Charge Mode"
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/script/charge.sh
 
-LOGGER "$0" "BOOTING" "Setting Default CPU Governor"
-GET_VAR "device" "cpu/default" >"$(GET_VAR "device" "cpu/governor")"
-GET_VAR "device" "cpu/sampling_rate_default" >"$(GET_VAR "device" "cpu/sampling_rate")"
-GET_VAR "device" "cpu/up_threshold_default" >"$(GET_VAR "device" "cpu/up_threshold")"
-GET_VAR "device" "cpu/sampling_down_factor_default" >"$(GET_VAR "device" "cpu/sampling_down_factor")"
-GET_VAR "device" "cpu/io_is_busy_default" >"$(GET_VAR "device" "cpu/io_is_busy")"
-
 LOGGER "$0" "BOOTING" "Setting up SDL Controller Map"
 for LIB_D in lib lib32; do
 	GCDB="gamecontrollerdb.txt"

--- a/script/system/startup.sh
+++ b/script/system/startup.sh
@@ -95,8 +95,8 @@ fi
 LOGGER "$0" "BOOTING" "Starting Low Power Indicator"
 /opt/muos/script/system/lowpower.sh &
 
-LOGGER "$0" "BOOTING" "Precaching muX and RetroArch System"
-/opt/muos/bin/vmtouch -tfb "/opt/muos/preload.txt" &
+LOGGER "$0" "BOOTING" "Precaching RetroArch System"
+ionice -c idle /opt/muos/bin/vmtouch -tfb /opt/muos/preload.txt &
 
 LOGGER "$0" "BOOTING" "Starting Storage Watchdog"
 /opt/muos/script/mount/sdcard.sh


### PR DESCRIPTION
### Performance gains

I measured boot times in the `4d8da591` (White Room) hero build against the modified changes, using two approaches:

1. Total boot time (measured via video, from last frame before green LED to first frame after `muxlaunch` screen).
2. muOS startup time (measured via timestamps in `boot.log`).

I didn't do a statistically rigorous analysis, but FWIW, the time deltas in `boot.log` are consistent across several reboots.

| Device | Total boot time | muOS startup time | Logs |
| - | - | - | - |
| RG35XX-H (slow SD card) | 16 sec -> 12 sec | 8 sec -> 4 sec | [before](https://github.com/user-attachments/files/16823542/rg35xx.boot.base.log), [after](https://github.com/user-attachments/files/16823543/rg35xx.boot.modified.log) |
| RG40XX-H (faster SD card) | 12 sec -> 10 sec | 4 sec -> 2 sec | [before](https://github.com/user-attachments/files/16823544/rg40xx.boot.base.log), [after](https://github.com/user-attachments/files/16823545/rg40xx.boot.modified.log) |

See also the [videos used to compare total boot time](https://imgur.com/a/xMKndXa).

The speedup is more impactful on devices with slower storage, which makes sense, but in either case it appears to give about a 50% improvement to `boot.log` time, at least on my hardware and configuration.

### Changes

* (Main improvement) Starts mounting SD card storage partitions in the background as soon as udevd settles down, then continues booting in parallel, only blocking when storage bind mounts are absolutely necessary (e.g., we start touching the theme, catalogue, etc.). This is where most of the speedup comes from.
* Runs vmtouch preloading of RetroArch and its shared libs at idle IO priority so it'll use spare IOPS, but won't slow down more urgent parts of the startup sequence.
* Uses the default performance governor for the entirety of the boot process, only switching to ondemand when entering the frontend main loop.
* (Not performance related) Moves copying of `boot.log` to `/mnt/mmc/MUOS/log/boot` to right before the frontend main loop so that all the boot log messages appear there, including the ones from `frontend.sh`.

I've tested this on the RG35XX-H and RG40XX-H, and verified that SD2 bind mounts still work, as does SD1 fallback. I've also verified that hotplugging (and hot-unplugging) of SD2 still works (adjusting the bind mounts appropriately), as does hotplugging (and hot-unplugging) of external USB storage.
