### PR TITLE
Set Mupen storage paths in default config instead of overwriting on launch

### DIFF
--- a/device/rg28xx/control/mupen64plus-gl64.cfg
+++ b/device/rg28xx/control/mupen64plus-gl64.cfg
@@ -58,11 +58,11 @@ CurrentStateSlot = 0
 # Activate the R4300 debugger when ROM execution begins, if core was built with Debugger support
 EnableDebugger = False
 # Path to directory where screenshots are saved. If this is blank, the default value of ${UserDataPath}/screenshot will be used
-ScreenshotPath = "/mnt/mmc/MUOS/screenshot"
+ScreenshotPath = "/run/muos/storage/screenshot"
 # Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveStatePath = "/mnt/mmc/MUOS/save/state/Mupen64Plus"
+SaveStatePath = "/run/muos/storage/save/state/Mupen64Plus"
 # Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveSRAMPath = "/mnt/mmc/MUOS/save/file/Mupen64Plus"
+SaveSRAMPath = "/run/muos/storage/save/file/Mupen64Plus"
 # Path to a directory to search when looking for shared data files
 SharedDataPath = "/mnt/mmc/MUOS/emulator/mupen64plus/configs"
 # Randomize PI/SI Interrupt Timing

--- a/device/rg28xx/control/mupen64plus-rice.cfg
+++ b/device/rg28xx/control/mupen64plus-rice.cfg
@@ -58,11 +58,11 @@ CurrentStateSlot = 0
 # Activate the R4300 debugger when ROM execution begins, if core was built with Debugger support
 EnableDebugger = False
 # Path to directory where screenshots are saved. If this is blank, the default value of ${UserDataPath}/screenshot will be used
-ScreenshotPath = "/mnt/mmc/MUOS/screenshot"
+ScreenshotPath = "/run/muos/storage/screenshot"
 # Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveStatePath = "/mnt/mmc/MUOS/save/state/Mupen64Plus"
+SaveStatePath = "/run/muos/storage/save/state/Mupen64Plus"
 # Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveSRAMPath = "/mnt/mmc/MUOS/save/file/Mupen64Plus"
+SaveSRAMPath = "/run/muos/storage/save/file/Mupen64Plus"
 # Path to a directory to search when looking for shared data files
 SharedDataPath = "/mnt/mmc/MUOS/emulator/mupen64plus/configs"
 # Randomize PI/SI Interrupt Timing

--- a/device/rg35xx-2024/control/mupen64plus-gl64.cfg
+++ b/device/rg35xx-2024/control/mupen64plus-gl64.cfg
@@ -58,11 +58,11 @@ CurrentStateSlot = 0
 # Activate the R4300 debugger when ROM execution begins, if core was built with Debugger support
 EnableDebugger = False
 # Path to directory where screenshots are saved. If this is blank, the default value of ${UserDataPath}/screenshot will be used
-ScreenshotPath = "/mnt/mmc/MUOS/screenshot"
+ScreenshotPath = "/run/muos/storage/screenshot"
 # Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveStatePath = "/mnt/mmc/MUOS/save/state/Mupen64Plus"
+SaveStatePath = "/run/muos/storage/save/state/Mupen64Plus"
 # Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveSRAMPath = "/mnt/mmc/MUOS/save/file/Mupen64Plus"
+SaveSRAMPath = "/run/muos/storage/save/file/Mupen64Plus"
 # Path to a directory to search when looking for shared data files
 SharedDataPath = "/mnt/mmc/MUOS/emulator/mupen64plus/configs"
 # Randomize PI/SI Interrupt Timing

--- a/device/rg35xx-2024/control/mupen64plus-rice.cfg
+++ b/device/rg35xx-2024/control/mupen64plus-rice.cfg
@@ -58,11 +58,11 @@ CurrentStateSlot = 0
 # Activate the R4300 debugger when ROM execution begins, if core was built with Debugger support
 EnableDebugger = False
 # Path to directory where screenshots are saved. If this is blank, the default value of ${UserDataPath}/screenshot will be used
-ScreenshotPath = "/mnt/mmc/MUOS/screenshot"
+ScreenshotPath = "/run/muos/storage/screenshot"
 # Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveStatePath = "/mnt/mmc/MUOS/save/state/Mupen64Plus"
+SaveStatePath = "/run/muos/storage/save/state/Mupen64Plus"
 # Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveSRAMPath = "/mnt/mmc/MUOS/save/file/Mupen64Plus"
+SaveSRAMPath = "/run/muos/storage/save/file/Mupen64Plus"
 # Path to a directory to search when looking for shared data files
 SharedDataPath = "/mnt/mmc/MUOS/emulator/mupen64plus/configs"
 # Randomize PI/SI Interrupt Timing

--- a/device/rg35xx-h/control/mupen64plus-gl64.cfg
+++ b/device/rg35xx-h/control/mupen64plus-gl64.cfg
@@ -58,11 +58,11 @@ CurrentStateSlot = 0
 # Activate the R4300 debugger when ROM execution begins, if core was built with Debugger support
 EnableDebugger = False
 # Path to directory where screenshots are saved. If this is blank, the default value of ${UserDataPath}/screenshot will be used
-ScreenshotPath = "/mnt/mmc/MUOS/screenshot"
+ScreenshotPath = "/run/muos/storage/screenshot"
 # Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveStatePath = "/mnt/mmc/MUOS/save/state/Mupen64Plus"
+SaveStatePath = "/run/muos/storage/save/state/Mupen64Plus"
 # Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveSRAMPath = "/mnt/mmc/MUOS/save/file/Mupen64Plus"
+SaveSRAMPath = "/run/muos/storage/save/file/Mupen64Plus"
 # Path to a directory to search when looking for shared data files
 SharedDataPath = "/mnt/mmc/MUOS/emulator/mupen64plus/configs"
 # Randomize PI/SI Interrupt Timing

--- a/device/rg35xx-h/control/mupen64plus-rice.cfg
+++ b/device/rg35xx-h/control/mupen64plus-rice.cfg
@@ -58,11 +58,11 @@ CurrentStateSlot = 0
 # Activate the R4300 debugger when ROM execution begins, if core was built with Debugger support
 EnableDebugger = False
 # Path to directory where screenshots are saved. If this is blank, the default value of ${UserDataPath}/screenshot will be used
-ScreenshotPath = "/mnt/mmc/MUOS/screenshot"
+ScreenshotPath = "/run/muos/storage/screenshot"
 # Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveStatePath = "/mnt/mmc/MUOS/save/state/Mupen64Plus"
+SaveStatePath = "/run/muos/storage/save/state/Mupen64Plus"
 # Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveSRAMPath = "/mnt/mmc/MUOS/save/file/Mupen64Plus"
+SaveSRAMPath = "/run/muos/storage/save/file/Mupen64Plus"
 # Path to a directory to search when looking for shared data files
 SharedDataPath = "/mnt/mmc/MUOS/emulator/mupen64plus/configs"
 # Randomize PI/SI Interrupt Timing

--- a/device/rg35xx-plus/control/mupen64plus-gl64.cfg
+++ b/device/rg35xx-plus/control/mupen64plus-gl64.cfg
@@ -58,11 +58,11 @@ CurrentStateSlot = 0
 # Activate the R4300 debugger when ROM execution begins, if core was built with Debugger support
 EnableDebugger = False
 # Path to directory where screenshots are saved. If this is blank, the default value of ${UserDataPath}/screenshot will be used
-ScreenshotPath = "/mnt/mmc/MUOS/screenshot"
+ScreenshotPath = "/run/muos/storage/screenshot"
 # Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveStatePath = "/mnt/mmc/MUOS/save/state/Mupen64Plus"
+SaveStatePath = "/run/muos/storage/save/state/Mupen64Plus"
 # Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveSRAMPath = "/mnt/mmc/MUOS/save/file/Mupen64Plus"
+SaveSRAMPath = "/run/muos/storage/save/file/Mupen64Plus"
 # Path to a directory to search when looking for shared data files
 SharedDataPath = "/mnt/mmc/MUOS/emulator/mupen64plus/configs"
 # Randomize PI/SI Interrupt Timing

--- a/device/rg35xx-plus/control/mupen64plus-rice.cfg
+++ b/device/rg35xx-plus/control/mupen64plus-rice.cfg
@@ -58,11 +58,11 @@ CurrentStateSlot = 0
 # Activate the R4300 debugger when ROM execution begins, if core was built with Debugger support
 EnableDebugger = False
 # Path to directory where screenshots are saved. If this is blank, the default value of ${UserDataPath}/screenshot will be used
-ScreenshotPath = "/mnt/mmc/MUOS/screenshot"
+ScreenshotPath = "/run/muos/storage/screenshot"
 # Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveStatePath = "/mnt/mmc/MUOS/save/state/Mupen64Plus"
+SaveStatePath = "/run/muos/storage/save/state/Mupen64Plus"
 # Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveSRAMPath = "/mnt/mmc/MUOS/save/file/Mupen64Plus"
+SaveSRAMPath = "/run/muos/storage/save/file/Mupen64Plus"
 # Path to a directory to search when looking for shared data files
 SharedDataPath = "/mnt/mmc/MUOS/emulator/mupen64plus/configs"
 # Randomize PI/SI Interrupt Timing

--- a/device/rg35xx-sp/control/mupen64plus-gl64.cfg
+++ b/device/rg35xx-sp/control/mupen64plus-gl64.cfg
@@ -58,11 +58,11 @@ CurrentStateSlot = 0
 # Activate the R4300 debugger when ROM execution begins, if core was built with Debugger support
 EnableDebugger = False
 # Path to directory where screenshots are saved. If this is blank, the default value of ${UserDataPath}/screenshot will be used
-ScreenshotPath = "/mnt/mmc/MUOS/screenshot"
+ScreenshotPath = "/run/muos/storage/screenshot"
 # Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveStatePath = "/mnt/mmc/MUOS/save/state/Mupen64Plus"
+SaveStatePath = "/run/muos/storage/save/state/Mupen64Plus"
 # Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveSRAMPath = "/mnt/mmc/MUOS/save/file/Mupen64Plus"
+SaveSRAMPath = "/run/muos/storage/save/file/Mupen64Plus"
 # Path to a directory to search when looking for shared data files
 SharedDataPath = "/mnt/mmc/MUOS/emulator/mupen64plus/configs"
 # Randomize PI/SI Interrupt Timing

--- a/device/rg35xx-sp/control/mupen64plus-rice.cfg
+++ b/device/rg35xx-sp/control/mupen64plus-rice.cfg
@@ -58,11 +58,11 @@ CurrentStateSlot = 0
 # Activate the R4300 debugger when ROM execution begins, if core was built with Debugger support
 EnableDebugger = False
 # Path to directory where screenshots are saved. If this is blank, the default value of ${UserDataPath}/screenshot will be used
-ScreenshotPath = "/mnt/mmc/MUOS/screenshot"
+ScreenshotPath = "/run/muos/storage/screenshot"
 # Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveStatePath = "/mnt/mmc/MUOS/save/state/Mupen64Plus"
+SaveStatePath = "/run/muos/storage/save/state/Mupen64Plus"
 # Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveSRAMPath = "/mnt/mmc/MUOS/save/file/Mupen64Plus"
+SaveSRAMPath = "/run/muos/storage/save/file/Mupen64Plus"
 # Path to a directory to search when looking for shared data files
 SharedDataPath = "/mnt/mmc/MUOS/emulator/mupen64plus/configs"
 # Randomize PI/SI Interrupt Timing

--- a/device/rg40xx-h/control/mupen64plus-gl64.cfg
+++ b/device/rg40xx-h/control/mupen64plus-gl64.cfg
@@ -58,11 +58,11 @@ CurrentStateSlot = 0
 # Activate the R4300 debugger when ROM execution begins, if core was built with Debugger support
 EnableDebugger = False
 # Path to directory where screenshots are saved. If this is blank, the default value of ${UserDataPath}/screenshot will be used
-ScreenshotPath = "/mnt/mmc/MUOS/screenshot"
+ScreenshotPath = "/run/muos/storage/screenshot"
 # Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveStatePath = "/mnt/mmc/MUOS/save/state/Mupen64Plus"
+SaveStatePath = "/run/muos/storage/save/state/Mupen64Plus"
 # Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveSRAMPath = "/mnt/mmc/MUOS/save/file/Mupen64Plus"
+SaveSRAMPath = "/run/muos/storage/save/file/Mupen64Plus"
 # Path to a directory to search when looking for shared data files
 SharedDataPath = "/mnt/mmc/MUOS/emulator/mupen64plus/configs"
 # Randomize PI/SI Interrupt Timing

--- a/device/rg40xx-h/control/mupen64plus-rice.cfg
+++ b/device/rg40xx-h/control/mupen64plus-rice.cfg
@@ -58,11 +58,11 @@ CurrentStateSlot = 0
 # Activate the R4300 debugger when ROM execution begins, if core was built with Debugger support
 EnableDebugger = False
 # Path to directory where screenshots are saved. If this is blank, the default value of ${UserDataPath}/screenshot will be used
-ScreenshotPath = "/mnt/mmc/MUOS/screenshot"
+ScreenshotPath = "/run/muos/storage/screenshot"
 # Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveStatePath = "/mnt/mmc/MUOS/save/state/Mupen64Plus"
+SaveStatePath = "/run/muos/storage/save/state/Mupen64Plus"
 # Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveSRAMPath = "/mnt/mmc/MUOS/save/file/Mupen64Plus"
+SaveSRAMPath = "/run/muos/storage/save/file/Mupen64Plus"
 # Path to a directory to search when looking for shared data files
 SharedDataPath = "/mnt/mmc/MUOS/emulator/mupen64plus/configs"
 # Randomize PI/SI Interrupt Timing

--- a/device/rg40xx-v/control/mupen64plus-gl64.cfg
+++ b/device/rg40xx-v/control/mupen64plus-gl64.cfg
@@ -58,11 +58,11 @@ CurrentStateSlot = 0
 # Activate the R4300 debugger when ROM execution begins, if core was built with Debugger support
 EnableDebugger = False
 # Path to directory where screenshots are saved. If this is blank, the default value of ${UserDataPath}/screenshot will be used
-ScreenshotPath = "/mnt/mmc/MUOS/screenshot"
+ScreenshotPath = "/run/muos/storage/screenshot"
 # Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveStatePath = "/mnt/mmc/MUOS/save/state/Mupen64Plus"
+SaveStatePath = "/run/muos/storage/save/state/Mupen64Plus"
 # Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveSRAMPath = "/mnt/mmc/MUOS/save/file/Mupen64Plus"
+SaveSRAMPath = "/run/muos/storage/save/file/Mupen64Plus"
 # Path to a directory to search when looking for shared data files
 SharedDataPath = "/mnt/mmc/MUOS/emulator/mupen64plus/configs"
 # Randomize PI/SI Interrupt Timing

--- a/device/rg40xx-v/control/mupen64plus-rice.cfg
+++ b/device/rg40xx-v/control/mupen64plus-rice.cfg
@@ -58,11 +58,11 @@ CurrentStateSlot = 0
 # Activate the R4300 debugger when ROM execution begins, if core was built with Debugger support
 EnableDebugger = False
 # Path to directory where screenshots are saved. If this is blank, the default value of ${UserDataPath}/screenshot will be used
-ScreenshotPath = "/mnt/mmc/MUOS/screenshot"
+ScreenshotPath = "/run/muos/storage/screenshot"
 # Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveStatePath = "/mnt/mmc/MUOS/save/state/Mupen64Plus"
+SaveStatePath = "/run/muos/storage/save/state/Mupen64Plus"
 # Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserDataPath}/save will be used
-SaveSRAMPath = "/mnt/mmc/MUOS/save/file/Mupen64Plus"
+SaveSRAMPath = "/run/muos/storage/save/file/Mupen64Plus"
 # Path to a directory to search when looking for shared data files
 SharedDataPath = "/mnt/mmc/MUOS/emulator/mupen64plus/configs"
 # Randomize PI/SI Interrupt Timing

--- a/script/launch/ext-mupen64plus.sh
+++ b/script/launch/ext-mupen64plus.sh
@@ -36,13 +36,6 @@ elif [ "$CORE" = "ext-mupen64plus-rice" ]; then
 	cp -f "$RICE_CFG" "$MP64_CFG"
 fi
 
-# Update paths in config based on storage preference.
-sed -i \
-	-e "s|^SaveSRAMPath = .*|SaveSRAMPath = \"/run/muos/storage/save/file/Mupen64Plus\"|" \
-	-e "s|^SaveStatePath = .*|SaveStatePath = \"/run/muos/storage/save/state/Mupen64Plus\"|" \
-	-e "s|^ScreenshotPath = .*|ScreenshotPath = \"/run/muos/storage/screenshot\"|" \
-	"$MP64_CFG"
-
 chmod +x "$EMUDIR"/mupen64plus
 cd "$EMUDIR" || exit
 


### PR DESCRIPTION
Like #194, but for Mupen.