### PR TITLE
Fix splash on reboot after factory reset (again)

### DIFF
--- a/script/system/reset.sh
+++ b/script/system/reset.sh
@@ -2,8 +2,6 @@
 
 . /opt/muos/script/var/func.sh
 
-umount "$(GET_VAR "device" "storage/rom/mount")"
-
 LOGGER "FACTORY RESET" "Expanding ROM Partition"
 printf "w\nw\n" | fdisk /dev/"$(GET_VAR "device" "storage/rom/dev")"
 parted ---pretend-input-tty /dev/"$(GET_VAR "device" "storage/rom/dev")" resizepart "$(GET_VAR "device" "storage/rom/num")" 100%
@@ -24,7 +22,7 @@ parted ---pretend-input-tty /dev/"$(GET_VAR "device" "storage/rom/dev")" set "$(
 parted ---pretend-input-tty /dev/"$(GET_VAR "device" "storage/rom/dev")" set "$(GET_VAR "device" "storage/rom/num")" hidden off
 parted ---pretend-input-tty /dev/"$(GET_VAR "device" "storage/rom/dev")" set "$(GET_VAR "device" "storage/rom/num")" msftdata on
 
-LOGGER "FACTORY RESET" "Remounting ROM Partition"
+LOGGER "FACTORY RESET" "Mounting ROM Partition"
 if mount -t "$(GET_VAR "device" "storage/rom/type")" -o rw,utf8,noatime,nofail \
 	/dev/"$(GET_VAR "device" "storage/rom/dev")$(GET_VAR "device" "storage/rom/sep")$(GET_VAR "device" "storage/rom/num")" \
 	"$(GET_VAR "device" "storage/rom/mount")"; then
@@ -53,6 +51,9 @@ fi
 
 LOGGER "$0" "FACTORY RESET" "Purging init directory"
 rm -rf /opt/muos/init
+
+LOGGER "$0" "FACTORY RESET" "Binding Storage Mounts"
+/opt/muos/script/var/init/storage.sh
 
 if [ "$(GET_VAR "device" "board/network")" -eq 1 ]; then
 	LOGGER "$0" "FACTORY RESET" "Changing Network MAC Address"


### PR DESCRIPTION
NOTE: This should work, but I have NOT manually tested it since it's honestly fairly tricky to actually test changes to the reset flow.

Small cosmetic thing, but I broke this... again. :) This time it's because of #193, which means we no longer have `/run/muos/storage/theme` bind-mounted after the factory reset, and so we can't pull the splash screen out of the active theme in reboot flow.

Just creating the bind mounts is quick, and it means the theme is available in case e.g. `muxcredits` wants to use it in the future, so I figured I'd do that.

Also, we no longer need to _unmount_ the ROM partition at the start of the script since it isn't mounted when we reset anymore. :)