### PR TITLE
Set aspect to Core Provided for a bunch of Arcade cores.

### DIFF
--- a/init/MUOS/info/config/FB Alpha 2012/FB Alpha 2012.cfg
+++ b/init/MUOS/info/config/FB Alpha 2012/FB Alpha 2012.cfg
@@ -1,0 +1,1 @@
+aspect_ratio_index = "22"

--- a/init/MUOS/info/config/FinalBurn Neo/FinalBurn Neo.cfg
+++ b/init/MUOS/info/config/FinalBurn Neo/FinalBurn Neo.cfg
@@ -1,0 +1,1 @@
+aspect_ratio_index = "22"

--- a/init/MUOS/info/config/MAME 2000/MAME 2000.cfg
+++ b/init/MUOS/info/config/MAME 2000/MAME 2000.cfg
@@ -1,0 +1,1 @@
+aspect_ratio_index = "22"

--- a/init/MUOS/info/config/MAME 2003 (0.78)/MAME 2003 (0.78).cfg
+++ b/init/MUOS/info/config/MAME 2003 (0.78)/MAME 2003 (0.78).cfg
@@ -1,0 +1,1 @@
+aspect_ratio_index = "22"

--- a/init/MUOS/info/config/MAME 2003-Plus/MAME 2003-Plus.cfg
+++ b/init/MUOS/info/config/MAME 2003-Plus/MAME 2003-Plus.cfg
@@ -1,0 +1,1 @@
+aspect_ratio_index = "22"

--- a/init/MUOS/info/config/MAME 2003/MAME 2003.cfg
+++ b/init/MUOS/info/config/MAME 2003/MAME 2003.cfg
@@ -1,0 +1,1 @@
+aspect_ratio_index = "22"

--- a/init/MUOS/info/config/MAME 2010/MAME 2010.cfg
+++ b/init/MUOS/info/config/MAME 2010/MAME 2010.cfg
@@ -1,0 +1,1 @@
+aspect_ratio_index = "22"

--- a/init/MUOS/info/config/MAME 2015/MAME 2015.cfg
+++ b/init/MUOS/info/config/MAME 2015/MAME 2015.cfg
@@ -1,0 +1,1 @@
+aspect_ratio_index = "22"


### PR DESCRIPTION
Previously this was set to ``Full`` which stretched these pretty horribly,