### PR TITLE
Fix control.sh possibly running before mounts, and also fix device remaps to use storage pref

### DIFF
--- a/device/rg28xx/script/start.sh
+++ b/device/rg28xx/script/start.sh
@@ -53,5 +53,4 @@ if [ "$(GET_VAR "global" "settings/advanced/android")" -eq 1 ]; then
 	/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/adb.sh &
 fi
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/control.sh &
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/input/input.sh &

--- a/device/rg35xx-2024/script/start.sh
+++ b/device/rg35xx-2024/script/start.sh
@@ -53,5 +53,4 @@ if [ "$(GET_VAR "global" "settings/advanced/android")" -eq 1 ]; then
 	/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/adb.sh &
 fi
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/control.sh &
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/input/input.sh &

--- a/device/rg35xx-h/script/control.sh
+++ b/device/rg35xx-h/script/control.sh
@@ -47,9 +47,9 @@ for file in "$DEVICE_CONTROL_DIR/openbor/"*.ini; do
 done
 
 # Define Playstation remap paths
-DUCK_RMP="$(GET_VAR "device" "storage/rom/mount")/MUOS/info/config/remaps/DuckStation/DuckStation.rmp"
-PCSX_RMP="$(GET_VAR "device" "storage/rom/mount")/MUOS/info/config/remaps/PCSX-ReARMed/PCSX-ReARMed.rmp"
-SWAN_RMP="$(GET_VAR "device" "storage/rom/mount")/MUOS/info/config/remaps/SwanStation/SwanStation.rmp"
+DUCK_RMP=/run/muos/storage/info/config/remaps/DuckStation/DuckStation.rmp
+PCSX_RMP=/run/muos/storage/info/config/remaps/PCSX-ReARMed/PCSX-ReARMed.rmp
+SWAN_RMP=/run/muos/storage/info/config/remaps/SwanStation/SwanStation.rmp
 
 # Check for DuckStation remap
 DUCK_DIR=$(dirname "$DUCK_RMP")

--- a/device/rg35xx-h/script/start.sh
+++ b/device/rg35xx-h/script/start.sh
@@ -53,5 +53,4 @@ if [ "$(GET_VAR "global" "settings/advanced/android")" -eq 1 ]; then
 	/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/adb.sh &
 fi
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/control.sh &
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/input/input.sh &

--- a/device/rg35xx-plus/script/start.sh
+++ b/device/rg35xx-plus/script/start.sh
@@ -53,5 +53,4 @@ if [ "$(GET_VAR "global" "settings/advanced/android")" -eq 1 ]; then
 	/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/adb.sh &
 fi
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/control.sh &
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/input/input.sh &

--- a/device/rg35xx-sp/script/start.sh
+++ b/device/rg35xx-sp/script/start.sh
@@ -59,5 +59,4 @@ if [ "$(GET_VAR "global" "settings/advanced/android")" -eq 1 ]; then
 	/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/adb.sh &
 fi
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/control.sh &
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/input/input.sh &

--- a/device/rg40xx-h/script/control.sh
+++ b/device/rg40xx-h/script/control.sh
@@ -47,9 +47,9 @@ for file in "$DEVICE_CONTROL_DIR/openbor/"*.ini; do
 done
 
 # Define Playstation remap paths
-DUCK_RMP="$(GET_VAR "device" "storage/rom/mount")/MUOS/info/config/remaps/DuckStation/DuckStation.rmp"
-PCSX_RMP="$(GET_VAR "device" "storage/rom/mount")/MUOS/info/config/remaps/PCSX-ReARMed/PCSX-ReARMed.rmp"
-SWAN_RMP="$(GET_VAR "device" "storage/rom/mount")/MUOS/info/config/remaps/SwanStation/SwanStation.rmp"
+DUCK_RMP=/run/muos/storage/info/config/remaps/DuckStation/DuckStation.rmp
+PCSX_RMP=/run/muos/storage/info/config/remaps/PCSX-ReARMed/PCSX-ReARMed.rmp
+SWAN_RMP=/run/muos/storage/info/config/remaps/SwanStation/SwanStation.rmp
 
 # Check for DuckStation remap
 DUCK_DIR=$(dirname "$DUCK_RMP")

--- a/device/rg40xx-h/script/start.sh
+++ b/device/rg40xx-h/script/start.sh
@@ -53,5 +53,4 @@ if [ "$(GET_VAR "global" "settings/advanced/android")" -eq 1 ]; then
 	/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/adb.sh &
 fi
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/control.sh &
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/input/input.sh &

--- a/device/rg40xx-v/script/control.sh
+++ b/device/rg40xx-v/script/control.sh
@@ -47,9 +47,9 @@ for file in "$DEVICE_CONTROL_DIR/openbor/"*.ini; do
 done
 
 # Define Playstation remap paths
-DUCK_RMP="$(GET_VAR "device" "storage/rom/mount")/MUOS/info/config/remaps/DuckStation/DuckStation.rmp"
-PCSX_RMP="$(GET_VAR "device" "storage/rom/mount")/MUOS/info/config/remaps/PCSX-ReARMed/PCSX-ReARMed.rmp"
-SWAN_RMP="$(GET_VAR "device" "storage/rom/mount")/MUOS/info/config/remaps/SwanStation/SwanStation.rmp"
+DUCK_RMP=/run/muos/storage/info/config/remaps/DuckStation/DuckStation.rmp
+PCSX_RMP=/run/muos/storage/info/config/remaps/PCSX-ReARMed/PCSX-ReARMed.rmp
+SWAN_RMP=/run/muos/storage/info/config/remaps/SwanStation/SwanStation.rmp
 
 # Check for DuckStation remap
 DUCK_DIR=$(dirname "$DUCK_RMP")

--- a/device/rg40xx-v/script/start.sh
+++ b/device/rg40xx-v/script/start.sh
@@ -53,5 +53,4 @@ if [ "$(GET_VAR "global" "settings/advanced/android")" -eq 1 ]; then
 	/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/adb.sh &
 fi
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/control.sh &
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/input/input.sh &

--- a/script/system/startup.sh
+++ b/script/system/startup.sh
@@ -111,6 +111,9 @@ done
 LOGGER "$0" "BOOTING" "Detecting Charge Mode"
 /opt/muos/device/"$DEV_BOARD"/script/charge.sh
 
+LOGGER "$0" "BOOTING" "Setting Device Controls"
+/opt/muos/device/"$DEV_BOARD"/script/control.sh &
+
 LOGGER "$0" "BOOTING" "Setting up SDL Controller Map"
 for LIB_D in lib lib32; do
 	GCDB="gamecontrollerdb.txt"


### PR DESCRIPTION
Fixes a bug I introduced in #193. Right now, the device config file restoration races with the mounting code. We mount `/mnt/mmc` early and run `control.sh` relatively late, which is probably why nobody's noticed this... but to be safe, we should run `control.sh` only _after_ mounting is verified to be complete.

Also writes the DualShock remaps to the active storage mount rather than always SD1 ([found here](https://discord.com/channels/1152022492001603615/1282541611011670103/1282552957388460133)).