### PR TITLE
Split PCE/PCECD. Split SG-1000

### DIFF
--- a/init/MUOS/info/assign/NEC PC Engine CD.ini
+++ b/init/MUOS/info/assign/NEC PC Engine CD.ini
@@ -1,16 +1,20 @@
 [global]
-name=NEC PC Engine
+name=NEC PC Engine CD
 default=Beetle PCE Fast
-catalogue=NEC PC Engine
+catalogue=NEC PC Engine CD
 cache=0
 governor=ondemand
 
+[bios]
+file_0=syscard3.pce
+hash_0=38179df8f4ac870017db21ebcbf53114
+
 [Beetle PCE Fast]
 core=mednafen_pce_fast_libretro.so
-bios_required=0
+bios_required=1
 external=0
 
 [Mednafen PCE]
 core=pce_libretro.so
-bios_required=0
+bios_required=1
 external=0

--- a/init/MUOS/info/assign/Sega Mega CD - Sega CD.ini
+++ b/init/MUOS/info/assign/Sega Mega CD - Sega CD.ini
@@ -5,11 +5,25 @@ catalogue=Sega Mega CD - Sega CD
 cache=0
 governor=ondemand
 
+[bios]
+file_0=bios_CD_E.bin
+hash_0=e66fa1dc5820d254611fdcdba0662372
+file_1=bios_CD_U.bin
+hash_1=854b9150240a198070150e4566ae1290
+file_2=bios_CD_J.bin
+hash_2=278a9397d192149e84e820ac621a8edd
+
 [Genesis Plus GX]
 core=genesis_plus_gx_libretro.so
+bios_required=1
+external=0
 
 [Genesis Plus GX Wide]
 core=genesis_plus_gx_wide_libretro.so
+bios_required=1
+external=0
 
 [PicoDrive]
 core=picodrive_libretro.so
+bios_required=1
+external=0

--- a/init/MUOS/info/assign/Sega SG-1000.ini
+++ b/init/MUOS/info/assign/Sega SG-1000.ini
@@ -1,0 +1,15 @@
+[global]
+name=Sega SG-1000
+default=Genesis Plus GX
+catalogue=Sega SG-1000
+cache=0
+governor=ondemand
+
+[blueMSX]
+core=bluemsx_libretro.so
+
+[Gearsystem]
+core=gearsystem_libretro.so
+
+[Genesis Plus GX]
+core=genesis_plus_gx_libretro.so


### PR DESCRIPTION
As per the discussion here: https://discord.com/channels/1152022492001603615/1282483900349681777
I have created a new entry in MUOS/info/assign for
NEC PC Engine CD.ini
Sega SG-1000.ini

Additionally I've added the missing BIOS information from Sega Mega CD while I was here.