### PR TITLE
Only set mustard RGB on boot during factory reset

### DIFF
--- a/script/system/startup.sh
+++ b/script/system/startup.sh
@@ -7,10 +7,6 @@
 /opt/muos/script/var/init/global.sh init
 
 DEV_BOARD=$(GET_VAR "device" "board/name")
-case "$DEV_BOARD" in
-	rg40xx*) /opt/muos/device/"$DEV_BOARD"/script/led_control.sh 2 255 225 173 1 ;;
-	*) ;;
-esac
 
 echo "pipewire" >"$AUDIO_SRC"
 
@@ -48,6 +44,11 @@ LOGGER "$0" "BOOTING" "Starting Pipewire"
 /opt/muos/script/system/pipewire.sh &
 
 if [ "$(GET_VAR "global" "boot/factory_reset")" -eq 1 ]; then
+	case "$DEV_BOARD" in
+		rg40xx*) /opt/muos/device/"$DEV_BOARD"/script/led_control.sh 2 255 225 173 1 ;;
+		*) ;;
+	esac
+
 	LOGGER "$0" "FACTORY RESET" "Setting date time to default"
 	date 090100002024
 	hwclock -w


### PR DESCRIPTION
As discussed [on Discord](https://discord.com/channels/1152022492001603615/1283979695150600214). We boot super quick now, and restore the previous RGB setting on startup, so the mustard only flashes for a brief second anyway. (Of course factory reset is different. Left it there as Corey suggested.)