### PR TITLE
Check AXP boot_mode for charger detection on boot

### DIFF
--- a/device/rg28xx/config.ini
+++ b/device/rg28xx/config.ini
@@ -105,6 +105,7 @@ rotation = 1
 blitter_disabled = 0
 
 [battery]
+boot_mode = /sys/class/power_supply/axp2202-battery/boot_mode
 capacity = /sys/class/power_supply/axp2202-battery/capacity
 health = /sys/class/power_supply/axp2202-battery/health
 voltage = /sys/class/power_supply/axp2202-battery/voltage_now

--- a/device/rg28xx/script/charge.sh
+++ b/device/rg28xx/script/charge.sh
@@ -2,7 +2,7 @@
 
 . /opt/muos/script/var/func.sh
 
-if [ "$(cat "$(GET_VAR "device" "battery/charger")")" -eq 1 ] && [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
+if [ "$(cat "$(GET_VAR "device" "battery/boot_mode")")" -eq 1 ] && [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
 	SET_VAR "system" "foreground_process" "muxcharge"
 
 	if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then

--- a/device/rg35xx-2024/config.ini
+++ b/device/rg35xx-2024/config.ini
@@ -105,6 +105,7 @@ rotation = 0
 blitter_disabled = 1
 
 [battery]
+boot_mode = /sys/class/power_supply/axp2202-battery/boot_mode
 capacity = /sys/class/power_supply/axp2202-battery/capacity
 health = /sys/class/power_supply/axp2202-battery/health
 voltage = /sys/class/power_supply/axp2202-battery/voltage_now

--- a/device/rg35xx-2024/script/charge.sh
+++ b/device/rg35xx-2024/script/charge.sh
@@ -2,7 +2,7 @@
 
 . /opt/muos/script/var/func.sh
 
-if [ "$(cat "$(GET_VAR "device" "battery/charger")")" -eq 1 ] && [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
+if [ "$(cat "$(GET_VAR "device" "battery/boot_mode")")" -eq 1 ] && [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
 	SET_VAR "system" "foreground_process" "muxcharge"
 
 	if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then

--- a/device/rg35xx-h/config.ini
+++ b/device/rg35xx-h/config.ini
@@ -105,6 +105,7 @@ rotation = 0
 blitter_disabled = 1
 
 [battery]
+boot_mode = /sys/class/power_supply/axp2202-battery/boot_mode
 capacity = /sys/class/power_supply/axp2202-battery/capacity
 health = /sys/class/power_supply/axp2202-battery/health
 voltage = /sys/class/power_supply/axp2202-battery/voltage_now

--- a/device/rg35xx-h/script/charge.sh
+++ b/device/rg35xx-h/script/charge.sh
@@ -2,7 +2,7 @@
 
 . /opt/muos/script/var/func.sh
 
-if [ "$(cat "$(GET_VAR "device" "battery/charger")")" -eq 1 ] && [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
+if [ "$(cat "$(GET_VAR "device" "battery/boot_mode")")" -eq 1 ] && [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
 	SET_VAR "system" "foreground_process" "muxcharge"
 
 	if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then

--- a/device/rg35xx-plus/config.ini
+++ b/device/rg35xx-plus/config.ini
@@ -105,6 +105,7 @@ rotation = 0
 blitter_disabled = 1
 
 [battery]
+boot_mode = /sys/class/power_supply/axp2202-battery/boot_mode
 capacity = /sys/class/power_supply/axp2202-battery/capacity
 health = /sys/class/power_supply/axp2202-battery/health
 voltage = /sys/class/power_supply/axp2202-battery/voltage_now

--- a/device/rg35xx-plus/script/charge.sh
+++ b/device/rg35xx-plus/script/charge.sh
@@ -2,7 +2,7 @@
 
 . /opt/muos/script/var/func.sh
 
-if [ "$(cat "$(GET_VAR "device" "battery/charger")")" -eq 1 ] && [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
+if [ "$(cat "$(GET_VAR "device" "battery/boot_mode")")" -eq 1 ] && [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
 	SET_VAR "system" "foreground_process" "muxcharge"
 
 	if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then

--- a/device/rg35xx-sp/config.ini
+++ b/device/rg35xx-sp/config.ini
@@ -105,6 +105,7 @@ rotation = 0
 blitter_disabled = 1
 
 [battery]
+boot_mode = /sys/class/power_supply/axp2202-battery/boot_mode
 capacity = /sys/class/power_supply/axp2202-battery/capacity
 health = /sys/class/power_supply/axp2202-battery/health
 voltage = /sys/class/power_supply/axp2202-battery/voltage_now

--- a/device/rg35xx-sp/script/charge.sh
+++ b/device/rg35xx-sp/script/charge.sh
@@ -2,7 +2,7 @@
 
 . /opt/muos/script/var/func.sh
 
-if [ "$(cat "$(GET_VAR "device" "battery/charger")")" -eq 1 ] && [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
+if [ "$(cat "$(GET_VAR "device" "battery/boot_mode")")" -eq 1 ] && [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
 	SET_VAR "system" "foreground_process" "muxcharge"
 
 	if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then

--- a/device/rg40xx-h/config.ini
+++ b/device/rg40xx-h/config.ini
@@ -105,6 +105,7 @@ rotation = 0
 blitter_disabled = 1
 
 [battery]
+boot_mode = /sys/class/power_supply/axp2202-battery/boot_mode
 capacity = /sys/class/power_supply/axp2202-battery/capacity
 health = /sys/class/power_supply/axp2202-battery/health
 voltage = /sys/class/power_supply/axp2202-battery/voltage_now

--- a/device/rg40xx-h/script/charge.sh
+++ b/device/rg40xx-h/script/charge.sh
@@ -2,9 +2,8 @@
 
 . /opt/muos/script/var/func.sh
 
-if [ "$(cat "$(GET_VAR "device" "battery/charger")")" -eq 1 ] && [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
+if [ "$(cat "$(GET_VAR "device" "battery/boot_mode")")" -eq 1 ] && [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
 	SET_VAR "system" "foreground_process" "muxcharge"
-	/opt/muos/device/rg40xx-h/script/led_control.sh 1 0 0 0 0 0 0 0
 
 	if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 		mount -t debugfs debugfs /sys/kernel/debug

--- a/device/rg40xx-v/config.ini
+++ b/device/rg40xx-v/config.ini
@@ -105,6 +105,7 @@ rotation = 0
 blitter_disabled = 1
 
 [battery]
+boot_mode = /sys/class/power_supply/axp2202-battery/boot_mode
 capacity = /sys/class/power_supply/axp2202-battery/capacity
 health = /sys/class/power_supply/axp2202-battery/health
 voltage = /sys/class/power_supply/axp2202-battery/voltage_now

--- a/device/rg40xx-v/script/charge.sh
+++ b/device/rg40xx-v/script/charge.sh
@@ -2,9 +2,8 @@
 
 . /opt/muos/script/var/func.sh
 
-if [ "$(cat "$(GET_VAR "device" "battery/charger")")" -eq 1 ] && [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
+if [ "$(cat "$(GET_VAR "device" "battery/boot_mode")")" -eq 1 ] && [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
 	SET_VAR "system" "foreground_process" "muxcharge"
-	/opt/muos/device/rg40xx-v/script/led_control.sh 1 0 0 0 0 0 0 0
 
 	if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 		mount -t debugfs debugfs /sys/kernel/debug

--- a/script/var/init/device.sh
+++ b/script/var/init/device.sh
@@ -21,7 +21,7 @@ CONFIG_CLEARED=0
 CONFIG_FILE="$DEVICE_CONFIG"
 
 AUDIO_VARS="platform object control channel min max"
-BATTERY_VARS="capacity health voltage charger"
+BATTERY_VARS="boot_mode capacity health voltage charger"
 CPU_VARS="cores default governor scaler sampling_rate up_threshold sampling_down_factor io_is_busy sampling_rate_default up_threshold_default sampling_down_factor_default io_is_busy_default"
 BOARD_VARS="name home network bluetooth portmaster lid hdmi event debugfs rtc rumble udc"
 INPUT_VARS="ev0 ev1 axis_min axis_max"


### PR DESCRIPTION
It was bugging me that when I selected "Reboot" in muOS with a charging cable connected, the system restarted into muxcharge and I had to hit power to boot to the launcher.

It appears `/sys/class/power_supply/axp2202-battery/boot_mode` is 1 when the system powered on due to charger connect, and 0 otherwise (including when rebooting from software, even with a charger connected). Updated `charge.sh` to check that instead instead of `axp2202-usb/online`.

I also removed a couple of `led_control.sh` calls to shut off LEDs. These should be unnecessary now that we no longer set the mustard RGB on early boot before `charge.sh` runs (#226).