### PR TITLE
Work around reversed RG40XX-H speaker channels

### DIFF
--- a/device/rg40xx-h/script/spk.sh
+++ b/device/rg40xx-h/script/spk.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# The RG40XX-H has swapped audio channels for speakers, but not for headphones.
+#
+# The new kernel in version 1.0.3 of the stock firmware resolves this bug, but
+# we currently use a patched version of an older stock kernel (to fix cardinal
+# snapping issues), and upgrading it isn't trivial.
+#
+# For now, poll spk_state (0 -> headphones plugged, 1 -> headphones unplugged)
+# and swap DACL and DACR when the state changes.
+
+while true; do
+	STATE="$(cat /sys/class/power_supply/axp2202-battery/spk_state)"
+	if [ "$STATE" != "$LAST_STATE" ]; then
+		case "$STATE" in
+			0)
+				# Headphones: Normal channel mapping
+				amixer -c 0 set 'OutputL Mixer DACL' on
+				amixer -c 0 set 'OutputL Mixer DACR' off
+				amixer -c 0 set 'OutputR Mixer DACL' off
+				amixer -c 0 set 'OutputR Mixer DACR' on
+				;;
+			1)
+				# Speakers: Reversed channel mapping
+				amixer -c 0 set 'OutputL Mixer DACL' off
+				amixer -c 0 set 'OutputL Mixer DACR' on
+				amixer -c 0 set 'OutputR Mixer DACL' on
+				amixer -c 0 set 'OutputR Mixer DACR' off
+				;;
+		esac
+	fi
+	LAST_STATE="$STATE"
+	sleep 1
+done

--- a/device/rg40xx-h/script/start.sh
+++ b/device/rg40xx-h/script/start.sh
@@ -49,4 +49,7 @@ echo on >/sys/devices/platform/soc/sdc0/mmc_host/mmc0/power/control
 # Switch GPU power policy
 echo always_on >/sys/devices/platform/gpu/power_policy &
 
+# Work around swapped speaker channels
+/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/spk.sh &
+
 /opt/muos/device/"$(GET_VAR "device" "board/name")"/input/input.sh &


### PR DESCRIPTION
Thanks @Duncanyoyo1 and others on muOS & Knulli Discords for help getting this far! :)

This is a hacky workaround and not really a proper fix... but it does appear to work. (If you think it's too hacky to merge, though, it won't hurt my feelings. I kinda hate this as a solution....)

If anyone figures out how to either 1) do this more properly in ALSA/PipeWire config or 2) replicate whatever changes the 1.0.3 stock firmware made to fix this, that would certainly be preferable.