### PR TITLE
Use device serial number for stable hostname

### DIFF
--- a/script/system/reset.sh
+++ b/script/system/reset.sh
@@ -59,8 +59,8 @@ if [ "$(GET_VAR "device" "board/network")" -eq 1 ]; then
 	LOGGER "$0" "FACTORY RESET" "Changing Network MAC Address"
 	macchanger -r "$(GET_VAR "device" "network/iface")"
 
-	LOGGER "$0" "FACTORY RESET" "Setting Random Hostname"
-	HN=$(hostname)-$(head -c 5 /proc/sys/kernel/random/uuid)
+	LOGGER "$0" "FACTORY RESET" "Setting Hostname"
+	HN="$(hostname)-$(/opt/muos/script/system/serial.sh | tail -c 9)"
 	hostname "$HN"
 	echo "$HN" >/etc/hostname
 fi

--- a/script/system/serial.sh
+++ b/script/system/serial.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Prints the current device's unique serial number.
+
+# For H700 devices, this comes from the SID / Chip-ID
+# (https://linux-sunxi.org/SID_Register_Guide). The stock U-Boot passes the
+# serial number portion of the Chip-ID in the snum kernel command line param.
+#
+# On stock kernels, this is also exposed via the sunxi_chipid and sunxi_serial
+# fields in /sys/class/sunxi_info/sys_info. The values line up as follows:
+#
+# snum:                  ZZZZ      YYYYYYY XXXXXXXX
+# sunxi_chipid: 33806c00 ZZZZ4808 0YYYYYYY XXXXXXXX
+# sunxi_serial: XXXXXXXX 0YYYYYYY 0000ZZZZ 00000000
+
+SERIAL="$(xargs -n 1 -a /proc/cmdline | sed -n s/^snum=//p)"
+[ -n "$SERIAL" ] || exit 1
+printf '%s\n' "$SERIAL"

--- a/script/system/usb.sh
+++ b/script/system/usb.sh
@@ -30,8 +30,7 @@ USB_PID() {
 }
 
 USB_SERIAL() {
-	# Parse device serial number passed by U-Boot out of kernel cmdline.
-	xargs -n 1 -a /proc/cmdline | sed -n s/^snum=//p
+	/opt/muos/script/system/serial.sh
 }
 
 USB_MANUFACTURER() {


### PR DESCRIPTION
Moves the util to read the device serial number to its own script, and uses that when setting the initial hostname so it stays stable across reflashes. Should make keeping track of multiple devices a little easier.

Used the end of the serial number rather than the start since the first couple bytes of the serial number seem not all that random.

(I made `serial.sh` a regular script instead of just adding a util function to be sourced since I was thinking this might be nice to show in system info in the frontend as well.)