### PR TITLE
Increase SIGTERM timeout on shutdown a bit

### DIFF
--- a/script/system/halt_internal.sh
+++ b/script/system/halt_internal.sh
@@ -110,9 +110,9 @@ shift 1
 	# 10s, SIGTERM them, then wait 5s more before resorting to SIGKILL.
 	RUN_WITH_TIMEOUT 10 5 'shutdown scripts' /etc/init.d/rcK
 
-	# Send SIGTERM to remaining processes. Wait up to 5s before mopping up
+	# Send SIGTERM to remaining processes. Wait up to 10s before mopping up
 	# with SIGKILL, then wait up to 1s more for everything to die.
-	if ! KILL_AND_WAIT 5 TERM "$@"; then
+	if ! KILL_AND_WAIT 10 TERM "$@"; then
 		KILL_AND_WAIT 1 KILL "$@"
 	fi
 


### PR DESCRIPTION
I've noticed that Syncthing sometimes takes a little longer to respond to SIGTERM. Extend the max delay on shutdown before sending SIGKILL to reduce risk of messing up the Syncthing DB.