### PR TITLE
Restore missing set-volume when changing audio

### DIFF
--- a/device/rg28xx/input/combo/audio.sh
+++ b/device/rg28xx/input/combo/audio.sh
@@ -20,7 +20,7 @@ SET_CURRENT() {
 	fi
 	printf "%d" "$PERCENTAGE" >"$VOLUME_FILE_PERCENT"
 
-	XDG_RUNTIME_DIR="/var/run" wpctl get-volume "$(GET_VAR "audio" "nid_internal")" | awk '{print int($2 * 100)}'
+	XDG_RUNTIME_DIR="/var/run" wpctl set-volume "$(GET_VAR "audio" "nid_internal")" "$PERCENTAGE%"
 
 	printf "%d" "$1" >"$VOLUME_FILE"
 	echo "Volume set to $1 ($PERCENTAGE%)"

--- a/device/rg35xx-2024/input/combo/audio.sh
+++ b/device/rg35xx-2024/input/combo/audio.sh
@@ -20,7 +20,7 @@ SET_CURRENT() {
 	fi
 	printf "%d" "$PERCENTAGE" >"$VOLUME_FILE_PERCENT"
 
-	XDG_RUNTIME_DIR="/var/run" wpctl get-volume "$(GET_VAR "audio" "nid_internal")" | awk '{print int($2 * 100)}'
+	XDG_RUNTIME_DIR="/var/run" wpctl set-volume "$(GET_VAR "audio" "nid_internal")" "$PERCENTAGE%"
 
 	printf "%d" "$1" >"$VOLUME_FILE"
 	echo "Volume set to $1 ($PERCENTAGE%)"

--- a/device/rg35xx-h/input/combo/audio.sh
+++ b/device/rg35xx-h/input/combo/audio.sh
@@ -20,7 +20,7 @@ SET_CURRENT() {
 	fi
 	printf "%d" "$PERCENTAGE" >"$VOLUME_FILE_PERCENT"
 
-	XDG_RUNTIME_DIR="/var/run" wpctl get-volume "$(GET_VAR "audio" "nid_internal")" | awk '{print int($2 * 100)}'
+	XDG_RUNTIME_DIR="/var/run" wpctl set-volume "$(GET_VAR "audio" "nid_internal")" "$PERCENTAGE%"
 
 	printf "%d" "$1" >"$VOLUME_FILE"
 	echo "Volume set to $1 ($PERCENTAGE%)"

--- a/device/rg35xx-plus/input/combo/audio.sh
+++ b/device/rg35xx-plus/input/combo/audio.sh
@@ -20,7 +20,7 @@ SET_CURRENT() {
 	fi
 	printf "%d" "$PERCENTAGE" >"$VOLUME_FILE_PERCENT"
 
-	XDG_RUNTIME_DIR="/var/run" wpctl get-volume "$(GET_VAR "audio" "nid_internal")" | awk '{print int($2 * 100)}'
+	XDG_RUNTIME_DIR="/var/run" wpctl set-volume "$(GET_VAR "audio" "nid_internal")" "$PERCENTAGE%"
 
 	printf "%d" "$1" >"$VOLUME_FILE"
 	echo "Volume set to $1 ($PERCENTAGE%)"

--- a/device/rg35xx-sp/input/combo/audio.sh
+++ b/device/rg35xx-sp/input/combo/audio.sh
@@ -20,7 +20,7 @@ SET_CURRENT() {
 	fi
 	printf "%d" "$PERCENTAGE" >"$VOLUME_FILE_PERCENT"
 
-	XDG_RUNTIME_DIR="/var/run" wpctl get-volume "$(GET_VAR "audio" "nid_internal")" | awk '{print int($2 * 100)}'
+	XDG_RUNTIME_DIR="/var/run" wpctl set-volume "$(GET_VAR "audio" "nid_internal")" "$PERCENTAGE%"
 
 	printf "%d" "$1" >"$VOLUME_FILE"
 	echo "Volume set to $1 ($PERCENTAGE%)"

--- a/device/rg40xx-h/input/combo/audio.sh
+++ b/device/rg40xx-h/input/combo/audio.sh
@@ -20,7 +20,7 @@ SET_CURRENT() {
 	fi
 	printf "%d" "$PERCENTAGE" >"$VOLUME_FILE_PERCENT"
 
-	XDG_RUNTIME_DIR="/var/run" wpctl get-volume "$(GET_VAR "audio" "nid_internal")" | awk '{print int($2 * 100)}'
+	XDG_RUNTIME_DIR="/var/run" wpctl set-volume "$(GET_VAR "audio" "nid_internal")" "$PERCENTAGE%"
 
 	printf "%d" "$1" >"$VOLUME_FILE"
 	echo "Volume set to $1 ($PERCENTAGE%)"

--- a/device/rg40xx-v/input/combo/audio.sh
+++ b/device/rg40xx-v/input/combo/audio.sh
@@ -20,7 +20,7 @@ SET_CURRENT() {
 	fi
 	printf "%d" "$PERCENTAGE" >"$VOLUME_FILE_PERCENT"
 
-	XDG_RUNTIME_DIR="/var/run" wpctl get-volume "$(GET_VAR "audio" "nid_internal")" | awk '{print int($2 * 100)}'
+	XDG_RUNTIME_DIR="/var/run" wpctl set-volume "$(GET_VAR "audio" "nid_internal")" "$PERCENTAGE%"
 
 	printf "%d" "$1" >"$VOLUME_FILE"
 	echo "Volume set to $1 ($PERCENTAGE%)"


### PR DESCRIPTION
Looks like a typo / copy-paste error (`get-volume` instead of `set-volume`) after all the changes for HDMI audio.