### PR TITLE
Add bind mount for 64-bit Drastic save files

### DIFF
--- a/script/var/init/storage.sh
+++ b/script/var/init/storage.sh
@@ -72,6 +72,9 @@ BIND_EMULATOR() {
 	mount --bind "$TARGET" "$MOUNT" || CRITICAL_FAILURE directory "$TARGET" "$MOUNT"
 }
 
+# Drastic
+BIND_EMULATOR save/drastic/backup drastic/backup
+
 # OpenBOR
 BIND_EMULATOR save/file/OpenBOR-Ext openbor/userdata/saves/openbor
 BIND_EMULATOR screenshot openbor/userdata/screenshots/openbor


### PR DESCRIPTION
Added this locally for my Drastic saves and figured I may as well PR it. But if some way to make this properly configurable is found, happy to close this. (Interestingly enough, the save _states_ seem to go to the right place already.)