### PR TITLE
Update scripts to use new device/current symlink

### DIFF
--- a/device/rg28xx/input/input.sh
+++ b/device/rg28xx/input/input.sh
@@ -8,7 +8,7 @@ mkdir -p /tmp/trigger
 
 killall -q "evtest"
 
-. /opt/muos/device/"$(GET_VAR "device" "board/name")"/input/map.sh
+. /opt/muos/device/current/input/map.sh
 
 KEY_COMBO=0
 RESUME_UPTIME="$(UPTIME)"
@@ -36,8 +36,8 @@ echo "awake" >"/tmp/sleep_state"
 # Make sure to put them in order of how you want them to work too!
 if [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
 	if [ "$(GET_VAR "global" "settings/general/shutdown")" -ge 0 ]; then
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/trigger/power.sh &
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/trigger/sleep.sh &
+		/opt/muos/device/current/input/trigger/power.sh &
+		/opt/muos/device/current/input/trigger/sleep.sh &
 	fi
 fi
 
@@ -82,23 +82,23 @@ fi
 		case "$STATE_MENU_LONG:$STATE_VOL_UP:$STATE_VOL_DOWN:$STATE_POWER_SHORT" in
 			1:1:0:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh U
+				/opt/muos/device/current/input/combo/bright.sh U
 				;;
 			1:0:1:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh D
+				/opt/muos/device/current/input/combo/bright.sh D
 				;;
 			1:0:0:1)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/screenshot.sh
+				/opt/muos/device/current/input/combo/screenshot.sh
 				;;
 			0:1:0:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/audio.sh U
+				/opt/muos/device/current/input/combo/audio.sh U
 				;;
 			0:0:1:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/audio.sh D
+				/opt/muos/device/current/input/combo/audio.sh D
 				;;
 		esac
 	fi

--- a/device/rg28xx/script/start.sh
+++ b/device/rg28xx/script/start.sh
@@ -4,27 +4,27 @@
 
 sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.conf
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/module.sh &
+/opt/muos/device/current/script/module.sh &
 
 if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 	mount -t debugfs debugfs /sys/kernel/debug
 fi
 
 if [ "$(GET_VAR "device" "board/hdmi")" -eq 1 ] && [ "$(GET_VAR "global" "settings/general/hdmi")" -gt -1 ]; then
-	/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/hdmi_start.sh &
+	/opt/muos/device/current/script/hdmi_start.sh &
 fi
 
 (
 	case "$(GET_VAR "global" "settings/advanced/brightness")" in
 		"high")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh "$(GET_VAR "device" "screen/bright")"
+			/opt/muos/device/current/input/combo/bright.sh "$(GET_VAR "device" "screen/bright")"
 			;;
 		"low")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh 10
+			/opt/muos/device/current/input/combo/bright.sh 10
 			;;
 		*)
 			PREV_BRIGHT=$(cat "/opt/muos/config/brightness.txt")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh "$PREV_BRIGHT"
+			/opt/muos/device/current/input/combo/bright.sh "$PREV_BRIGHT"
 			;;
 	esac
 ) &
@@ -49,5 +49,5 @@ echo on >/sys/devices/platform/soc/sdc0/mmc_host/mmc0/power/control
 # Switch GPU power policy
 echo always_on >/sys/devices/platform/gpu/power_policy &
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/input.sh &
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/idle.sh &
+/opt/muos/device/current/input/input.sh &
+/opt/muos/device/current/input/idle.sh &

--- a/device/rg35xx-2024/input/input.sh
+++ b/device/rg35xx-2024/input/input.sh
@@ -8,7 +8,7 @@ mkdir -p /tmp/trigger
 
 killall -q "evtest"
 
-. /opt/muos/device/"$(GET_VAR "device" "board/name")"/input/map.sh
+. /opt/muos/device/current/input/map.sh
 
 KEY_COMBO=0
 RESUME_UPTIME="$(UPTIME)"
@@ -36,8 +36,8 @@ echo "awake" >"/tmp/sleep_state"
 # Make sure to put them in order of how you want them to work too!
 if [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
 	if [ "$(GET_VAR "global" "settings/general/shutdown")" -ge 0 ]; then
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/trigger/power.sh &
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/trigger/sleep.sh &
+		/opt/muos/device/current/input/trigger/power.sh &
+		/opt/muos/device/current/input/trigger/sleep.sh &
 	fi
 fi
 
@@ -82,23 +82,23 @@ fi
 		case "$STATE_MENU_LONG:$STATE_VOL_UP:$STATE_VOL_DOWN:$STATE_POWER_SHORT" in
 			1:1:0:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh U
+				/opt/muos/device/current/input/combo/bright.sh U
 				;;
 			1:0:1:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh D
+				/opt/muos/device/current/input/combo/bright.sh D
 				;;
 			1:0:0:1)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/screenshot.sh
+				/opt/muos/device/current/input/combo/screenshot.sh
 				;;
 			0:1:0:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/audio.sh U
+				/opt/muos/device/current/input/combo/audio.sh U
 				;;
 			0:0:1:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/audio.sh D
+				/opt/muos/device/current/input/combo/audio.sh D
 				;;
 		esac
 	fi

--- a/device/rg35xx-2024/script/start.sh
+++ b/device/rg35xx-2024/script/start.sh
@@ -4,27 +4,27 @@
 
 sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.conf
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/module.sh &
+/opt/muos/device/current/script/module.sh &
 
 if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 	mount -t debugfs debugfs /sys/kernel/debug
 fi
 
 if [ "$(GET_VAR "device" "board/hdmi")" -eq 1 ] && [ "$(GET_VAR "global" "settings/general/hdmi")" -gt -1 ]; then
-	/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/hdmi_start.sh &
+	/opt/muos/device/current/script/hdmi_start.sh &
 fi
 
 (
 	case "$(GET_VAR "global" "settings/advanced/brightness")" in
 		"high")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh "$(GET_VAR "device" "screen/bright")"
+			/opt/muos/device/current/input/combo/bright.sh "$(GET_VAR "device" "screen/bright")"
 			;;
 		"low")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh 10
+			/opt/muos/device/current/input/combo/bright.sh 10
 			;;
 		*)
 			PREV_BRIGHT=$(cat "/opt/muos/config/brightness.txt")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh "$PREV_BRIGHT"
+			/opt/muos/device/current/input/combo/bright.sh "$PREV_BRIGHT"
 			;;
 	esac
 ) &
@@ -49,5 +49,5 @@ echo on >/sys/devices/platform/soc/sdc0/mmc_host/mmc0/power/control
 # Switch GPU power policy
 echo always_on >/sys/devices/platform/gpu/power_policy &
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/input.sh &
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/idle.sh &
+/opt/muos/device/current/input/input.sh &
+/opt/muos/device/current/input/idle.sh &

--- a/device/rg35xx-h/input/input.sh
+++ b/device/rg35xx-h/input/input.sh
@@ -8,7 +8,7 @@ mkdir -p /tmp/trigger
 
 killall -q "evtest"
 
-. /opt/muos/device/"$(GET_VAR "device" "board/name")"/input/map.sh
+. /opt/muos/device/current/input/map.sh
 
 KEY_COMBO=0
 RESUME_UPTIME="$(UPTIME)"
@@ -28,8 +28,8 @@ echo "awake" >"/tmp/sleep_state"
 # Make sure to put them in order of how you want them to work too!
 if [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
 	if [ "$(GET_VAR "global" "settings/general/shutdown")" -ge 0 ]; then
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/trigger/power.sh &
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/trigger/sleep.sh &
+		/opt/muos/device/current/input/trigger/power.sh &
+		/opt/muos/device/current/input/trigger/sleep.sh &
 	fi
 fi
 
@@ -74,23 +74,23 @@ fi
 		case "$STATE_MENU_LONG:$STATE_VOL_UP:$STATE_VOL_DOWN:$STATE_POWER_SHORT" in
 			1:1:0:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh U
+				/opt/muos/device/current/input/combo/bright.sh U
 				;;
 			1:0:1:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh D
+				/opt/muos/device/current/input/combo/bright.sh D
 				;;
 			1:0:0:1)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/screenshot.sh
+				/opt/muos/device/current/input/combo/screenshot.sh
 				;;
 			0:1:0:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/audio.sh U
+				/opt/muos/device/current/input/combo/audio.sh U
 				;;
 			0:0:1:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/audio.sh D
+				/opt/muos/device/current/input/combo/audio.sh D
 				;;
 		esac
 	fi

--- a/device/rg35xx-h/script/start.sh
+++ b/device/rg35xx-h/script/start.sh
@@ -4,27 +4,27 @@
 
 sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.conf
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/module.sh &
+/opt/muos/device/current/script/module.sh &
 
 if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 	mount -t debugfs debugfs /sys/kernel/debug
 fi
 
 if [ "$(GET_VAR "device" "board/hdmi")" -eq 1 ] && [ "$(GET_VAR "global" "settings/general/hdmi")" -gt -1 ]; then
-	/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/hdmi_start.sh &
+	/opt/muos/device/current/script/hdmi_start.sh &
 fi
 
 (
 	case "$(GET_VAR "global" "settings/advanced/brightness")" in
 		"high")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh "$(GET_VAR "device" "screen/bright")"
+			/opt/muos/device/current/input/combo/bright.sh "$(GET_VAR "device" "screen/bright")"
 			;;
 		"low")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh 10
+			/opt/muos/device/current/input/combo/bright.sh 10
 			;;
 		*)
 			PREV_BRIGHT=$(cat "/opt/muos/config/brightness.txt")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh "$PREV_BRIGHT"
+			/opt/muos/device/current/input/combo/bright.sh "$PREV_BRIGHT"
 			;;
 	esac
 ) &
@@ -49,5 +49,5 @@ echo on >/sys/devices/platform/soc/sdc0/mmc_host/mmc0/power/control
 # Switch GPU power policy
 echo always_on >/sys/devices/platform/gpu/power_policy &
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/input.sh &
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/idle.sh &
+/opt/muos/device/current/input/input.sh &
+/opt/muos/device/current/input/idle.sh &

--- a/device/rg35xx-plus/input/input.sh
+++ b/device/rg35xx-plus/input/input.sh
@@ -8,7 +8,7 @@ mkdir -p /tmp/trigger
 
 killall -q "evtest"
 
-. /opt/muos/device/"$(GET_VAR "device" "board/name")"/input/map.sh
+. /opt/muos/device/current/input/map.sh
 
 KEY_COMBO=0
 RESUME_UPTIME="$(UPTIME)"
@@ -36,8 +36,8 @@ echo "awake" >"/tmp/sleep_state"
 # Make sure to put them in order of how you want them to work too!
 if [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
 	if [ "$(GET_VAR "global" "settings/general/shutdown")" -ge 0 ]; then
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/trigger/power.sh &
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/trigger/sleep.sh &
+		/opt/muos/device/current/input/trigger/power.sh &
+		/opt/muos/device/current/input/trigger/sleep.sh &
 	fi
 fi
 
@@ -82,23 +82,23 @@ fi
 		case "$STATE_MENU_LONG:$STATE_VOL_UP:$STATE_VOL_DOWN:$STATE_POWER_SHORT" in
 			1:1:0:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh U
+				/opt/muos/device/current/input/combo/bright.sh U
 				;;
 			1:0:1:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh D
+				/opt/muos/device/current/input/combo/bright.sh D
 				;;
 			1:0:0:1)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/screenshot.sh
+				/opt/muos/device/current/input/combo/screenshot.sh
 				;;
 			0:1:0:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/audio.sh U
+				/opt/muos/device/current/input/combo/audio.sh U
 				;;
 			0:0:1:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/audio.sh D
+				/opt/muos/device/current/input/combo/audio.sh D
 				;;
 		esac
 	fi

--- a/device/rg35xx-plus/script/start.sh
+++ b/device/rg35xx-plus/script/start.sh
@@ -4,27 +4,27 @@
 
 sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.conf
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/module.sh &
+/opt/muos/device/current/script/module.sh &
 
 if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 	mount -t debugfs debugfs /sys/kernel/debug
 fi
 
 if [ "$(GET_VAR "device" "board/hdmi")" -eq 1 ] && [ "$(GET_VAR "global" "settings/general/hdmi")" -gt -1 ]; then
-	/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/hdmi_start.sh &
+	/opt/muos/device/current/script/hdmi_start.sh &
 fi
 
 (
 	case "$(GET_VAR "global" "settings/advanced/brightness")" in
 		"high")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh "$(GET_VAR "device" "screen/bright")"
+			/opt/muos/device/current/input/combo/bright.sh "$(GET_VAR "device" "screen/bright")"
 			;;
 		"low")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh 10
+			/opt/muos/device/current/input/combo/bright.sh 10
 			;;
 		*)
 			PREV_BRIGHT=$(cat "/opt/muos/config/brightness.txt")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh "$PREV_BRIGHT"
+			/opt/muos/device/current/input/combo/bright.sh "$PREV_BRIGHT"
 			;;
 	esac
 ) &
@@ -49,5 +49,5 @@ echo on >/sys/devices/platform/soc/sdc0/mmc_host/mmc0/power/control
 # Switch GPU power policy
 echo always_on >/sys/devices/platform/gpu/power_policy &
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/input.sh &
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/idle.sh &
+/opt/muos/device/current/input/input.sh &
+/opt/muos/device/current/input/idle.sh &

--- a/device/rg35xx-sp/input/input.sh
+++ b/device/rg35xx-sp/input/input.sh
@@ -8,7 +8,7 @@ mkdir -p /tmp/trigger
 
 killall -q "evtest"
 
-. /opt/muos/device/"$(GET_VAR "device" "board/name")"/input/map.sh
+. /opt/muos/device/current/input/map.sh
 
 KEY_COMBO=0
 RESUME_UPTIME="$(UPTIME)"
@@ -37,8 +37,8 @@ echo "awake" >"/tmp/sleep_state"
 # Make sure to put them in order of how you want them to work too!
 if [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
 	if [ "$(GET_VAR "global" "settings/general/shutdown")" -ge 0 ]; then
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/trigger/power.sh &
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/trigger/sleep.sh &
+		/opt/muos/device/current/input/trigger/power.sh &
+		/opt/muos/device/current/input/trigger/sleep.sh &
 	fi
 fi
 
@@ -83,23 +83,23 @@ fi
 		case "$STATE_MENU_LONG:$STATE_VOL_UP:$STATE_VOL_DOWN:$STATE_POWER_SHORT" in
 			1:1:0:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh U
+				/opt/muos/device/current/input/combo/bright.sh U
 				;;
 			1:0:1:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh D
+				/opt/muos/device/current/input/combo/bright.sh D
 				;;
 			1:0:0:1)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/screenshot.sh
+				/opt/muos/device/current/input/combo/screenshot.sh
 				;;
 			0:1:0:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/audio.sh U
+				/opt/muos/device/current/input/combo/audio.sh U
 				;;
 			0:0:1:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/audio.sh D
+				/opt/muos/device/current/input/combo/audio.sh D
 				;;
 		esac
 	fi

--- a/device/rg35xx-sp/script/start.sh
+++ b/device/rg35xx-sp/script/start.sh
@@ -10,27 +10,27 @@ fi
 
 sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.conf
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/module.sh &
+/opt/muos/device/current/script/module.sh &
 
 if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 	mount -t debugfs debugfs /sys/kernel/debug
 fi
 
 if [ "$(GET_VAR "device" "board/hdmi")" -eq 1 ] && [ "$(GET_VAR "global" "settings/general/hdmi")" -gt -1 ]; then
-	/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/hdmi_start.sh &
+	/opt/muos/device/current/script/hdmi_start.sh &
 fi
 
 (
 	case "$(GET_VAR "global" "settings/advanced/brightness")" in
 		"high")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh "$(GET_VAR "device" "screen/bright")"
+			/opt/muos/device/current/input/combo/bright.sh "$(GET_VAR "device" "screen/bright")"
 			;;
 		"low")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh 10
+			/opt/muos/device/current/input/combo/bright.sh 10
 			;;
 		*)
 			PREV_BRIGHT=$(cat "/opt/muos/config/brightness.txt")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh "$PREV_BRIGHT"
+			/opt/muos/device/current/input/combo/bright.sh "$PREV_BRIGHT"
 			;;
 	esac
 ) &
@@ -55,5 +55,5 @@ echo on >/sys/devices/platform/soc/sdc0/mmc_host/mmc0/power/control
 # Switch GPU power policy
 echo always_on >/sys/devices/platform/gpu/power_policy &
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/input.sh &
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/idle.sh &
+/opt/muos/device/current/input/input.sh &
+/opt/muos/device/current/input/idle.sh &

--- a/device/rg40xx-h/input/input.sh
+++ b/device/rg40xx-h/input/input.sh
@@ -8,7 +8,7 @@ mkdir -p /tmp/trigger
 
 killall -q "evtest"
 
-. /opt/muos/device/"$(GET_VAR "device" "board/name")"/input/map.sh
+. /opt/muos/device/current/input/map.sh
 
 KEY_COMBO=0
 RESUME_UPTIME="$(UPTIME)"
@@ -28,8 +28,8 @@ echo "awake" >"/tmp/sleep_state"
 # Make sure to put them in order of how you want them to work too!
 if [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
 	if [ "$(GET_VAR "global" "settings/general/shutdown")" -ge 0 ]; then
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/trigger/power.sh &
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/trigger/sleep.sh &
+		/opt/muos/device/current/input/trigger/power.sh &
+		/opt/muos/device/current/input/trigger/sleep.sh &
 	fi
 fi
 
@@ -74,23 +74,23 @@ fi
 		case "$STATE_MENU_LONG:$STATE_VOL_UP:$STATE_VOL_DOWN:$STATE_POWER_SHORT" in
 			1:1:0:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh U
+				/opt/muos/device/current/input/combo/bright.sh U
 				;;
 			1:0:1:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh D
+				/opt/muos/device/current/input/combo/bright.sh D
 				;;
 			1:0:0:1)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/screenshot.sh
+				/opt/muos/device/current/input/combo/screenshot.sh
 				;;
 			0:1:0:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/audio.sh U
+				/opt/muos/device/current/input/combo/audio.sh U
 				;;
 			0:0:1:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/audio.sh D
+				/opt/muos/device/current/input/combo/audio.sh D
 				;;
 		esac
 	fi

--- a/device/rg40xx-h/script/start.sh
+++ b/device/rg40xx-h/script/start.sh
@@ -4,27 +4,27 @@
 
 sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.conf
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/module.sh &
+/opt/muos/device/current/script/module.sh &
 
 if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 	mount -t debugfs debugfs /sys/kernel/debug
 fi
 
 if [ "$(GET_VAR "device" "board/hdmi")" -eq 1 ] && [ "$(GET_VAR "global" "settings/general/hdmi")" -gt -1 ]; then
-	/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/hdmi_start.sh &
+	/opt/muos/device/current/script/hdmi_start.sh &
 fi
 
 (
 	case "$(GET_VAR "global" "settings/advanced/brightness")" in
 		"high")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh "$(GET_VAR "device" "screen/bright")"
+			/opt/muos/device/current/input/combo/bright.sh "$(GET_VAR "device" "screen/bright")"
 			;;
 		"low")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh 10
+			/opt/muos/device/current/input/combo/bright.sh 10
 			;;
 		*)
 			PREV_BRIGHT=$(cat "/opt/muos/config/brightness.txt")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh "$PREV_BRIGHT"
+			/opt/muos/device/current/input/combo/bright.sh "$PREV_BRIGHT"
 			;;
 	esac
 ) &
@@ -50,7 +50,7 @@ echo on >/sys/devices/platform/soc/sdc0/mmc_host/mmc0/power/control
 echo always_on >/sys/devices/platform/gpu/power_policy &
 
 # Work around swapped speaker channels
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/spk.sh &
+/opt/muos/device/current/script/spk.sh &
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/input.sh &
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/idle.sh &
+/opt/muos/device/current/input/input.sh &
+/opt/muos/device/current/input/idle.sh &

--- a/device/rg40xx-v/input/input.sh
+++ b/device/rg40xx-v/input/input.sh
@@ -8,7 +8,7 @@ mkdir -p /tmp/trigger
 
 killall -q "evtest"
 
-. /opt/muos/device/"$(GET_VAR "device" "board/name")"/input/map.sh
+. /opt/muos/device/current/input/map.sh
 
 KEY_COMBO=0
 RESUME_UPTIME="$(UPTIME)"
@@ -28,8 +28,8 @@ echo "awake" >"/tmp/sleep_state"
 # Make sure to put them in order of how you want them to work too!
 if [ "$(GET_VAR "global" "boot/factory_reset")" -eq 0 ]; then
 	if [ "$(GET_VAR "global" "settings/general/shutdown")" -ge 0 ]; then
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/trigger/power.sh &
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/trigger/sleep.sh &
+		/opt/muos/device/current/input/trigger/power.sh &
+		/opt/muos/device/current/input/trigger/sleep.sh &
 	fi
 fi
 
@@ -74,23 +74,23 @@ fi
 		case "$STATE_MENU_LONG:$STATE_VOL_UP:$STATE_VOL_DOWN:$STATE_POWER_SHORT" in
 			1:1:0:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh U
+				/opt/muos/device/current/input/combo/bright.sh U
 				;;
 			1:0:1:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh D
+				/opt/muos/device/current/input/combo/bright.sh D
 				;;
 			1:0:0:1)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/screenshot.sh
+				/opt/muos/device/current/input/combo/screenshot.sh
 				;;
 			0:1:0:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/audio.sh U
+				/opt/muos/device/current/input/combo/audio.sh U
 				;;
 			0:0:1:0)
 				KEY_COMBO=1
-				/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/audio.sh D
+				/opt/muos/device/current/input/combo/audio.sh D
 				;;
 		esac
 	fi

--- a/device/rg40xx-v/script/start.sh
+++ b/device/rg40xx-v/script/start.sh
@@ -4,27 +4,27 @@
 
 sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.conf
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/module.sh &
+/opt/muos/device/current/script/module.sh &
 
 if [ "$(GET_VAR "device" "board/debugfs")" -eq 1 ]; then
 	mount -t debugfs debugfs /sys/kernel/debug
 fi
 
 if [ "$(GET_VAR "device" "board/hdmi")" -eq 1 ] && [ "$(GET_VAR "global" "settings/general/hdmi")" -gt -1 ]; then
-	/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/hdmi_start.sh &
+	/opt/muos/device/current/script/hdmi_start.sh &
 fi
 
 (
 	case "$(GET_VAR "global" "settings/advanced/brightness")" in
 		"high")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh "$(GET_VAR "device" "screen/bright")"
+			/opt/muos/device/current/input/combo/bright.sh "$(GET_VAR "device" "screen/bright")"
 			;;
 		"low")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh 10
+			/opt/muos/device/current/input/combo/bright.sh 10
 			;;
 		*)
 			PREV_BRIGHT=$(cat "/opt/muos/config/brightness.txt")
-			/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh "$PREV_BRIGHT"
+			/opt/muos/device/current/input/combo/bright.sh "$PREV_BRIGHT"
 			;;
 	esac
 ) &
@@ -49,5 +49,5 @@ echo on >/sys/devices/platform/soc/sdc0/mmc_host/mmc0/power/control
 # Switch GPU power policy
 echo always_on >/sys/devices/platform/gpu/power_policy &
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/input.sh &
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/idle.sh &
+/opt/muos/device/current/input/input.sh &
+/opt/muos/device/current/input/idle.sh &

--- a/init/MUOS/application/.rgbcontroller/rgbcontroller/command.lua
+++ b/init/MUOS/application/.rgbcontroller/rgbcontroller/command.lua
@@ -52,7 +52,7 @@ function command.run(settings, colors, double_colors)
         file:write(". /opt/muos/script/var/func.sh\n")
 
         -- Add the dynamic device-specific path with the correct arguments
-        file:write(string.format("/opt/muos/device/\"$(GET_VAR \"device\" \"board/name\")\"/script/led_control.sh %s\n", commandArgs))
+        file:write(string.format("/opt/muos/device/current/script/led_control.sh %s\n", commandArgs))
 
         file:close()
         print("Command saved to: " .. commandFile)
@@ -61,7 +61,7 @@ function command.run(settings, colors, double_colors)
     end
 
     -- Print the final command to the console for debugging
-    print("Running command: /opt/muos/device/\"$(GET_VAR \"device\" \"board/name\")\"/script/led_control.sh " .. commandArgs)
+    print("Running command: /opt/muos/device/current/script/led_control.sh " .. commandArgs)
 
     -- Execute the command in the system shell
     os.execute("/run/muos/storage/theme/active/rgb/rgbconf.sh")

--- a/init/MUOS/task/Restore RetroArch Configuration.sh
+++ b/init/MUOS/task/Restore RetroArch Configuration.sh
@@ -8,7 +8,7 @@ pkill -STOP muxtask
 
 echo "Restoring RetroArch Configuration"
 rm -f /run/muos/storage/info/config/retroarch.cfg
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/control.sh
+/opt/muos/device/current/script/control.sh
 
 echo "Sync Filesystem"
 sync

--- a/init/MUOS/theme/active/rgb/rgbconf.sh
+++ b/init/MUOS/theme/active/rgb/rgbconf.sh
@@ -1,1 +1,1 @@
-/opt/muos/device/rg40xx-h/script/led_control.sh 1 76 225 173 1 225 173 1
+/opt/muos/device/current/script/led_control.sh 1 76 225 173 1 225 173 1

--- a/script/mux/frontend.sh
+++ b/script/mux/frontend.sh
@@ -26,8 +26,8 @@ case "$DEV_BOARD" in
 	*) ;;
 esac
 
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/audio.sh I
-/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh I
+/opt/muos/device/current/input/combo/audio.sh I
+/opt/muos/device/current/input/combo/bright.sh I
 
 ACT_GO=/tmp/act_go
 APP_GO=/tmp/app_go

--- a/script/mux/frontend.sh
+++ b/script/mux/frontend.sh
@@ -20,7 +20,7 @@ case "$DEV_BOARD" in
 		if [ -f "$RGBCONF_SCRIPT" ]; then
 			"$RGBCONF_SCRIPT"
 		else
-			/opt/muos/device/"$DEV_BOARD"/script/led_control.sh 1 0 0 0 0 0 0 0
+			/opt/muos/device/current/script/led_control.sh 1 0 0 0 0 0 0 0
 		fi
 		;;
 	*) ;;

--- a/script/mux/theme.sh
+++ b/script/mux/theme.sh
@@ -30,7 +30,7 @@ case "$DEV_BOARD" in
 		if [ -f "$RGBCONF_SCRIPT" ]; then
 			"$RGBCONF_SCRIPT"
 		else
-			/opt/muos/device/"$DEV_BOARD"/script/led_control.sh 1 0 0 0 0 0 0 0
+			/opt/muos/device/current/script/led_control.sh 1 0 0 0 0 0 0 0
 		fi
 		;;
 	*) ;;

--- a/script/mux/theme.sh
+++ b/script/mux/theme.sh
@@ -10,7 +10,7 @@ fi
 
 THEME_DIR="/run/muos/storage/theme"
 
-BOOTLOGO_DEF="/opt/muos/device/$(GET_VAR "device" "board/name")/bootlogo.bmp"
+BOOTLOGO_DEF="/opt/muos/device/current/bootlogo.bmp"
 BOOTLOGO_NEW="$THEME_DIR/active/image/bootlogo.bmp"
 
 cp "$BOOTLOGO_DEF" "$(GET_VAR "device" "storage/boot/mount")/bootlogo.bmp"

--- a/script/mux/tweak.sh
+++ b/script/mux/tweak.sh
@@ -4,23 +4,23 @@
 
 C_BRIGHT="$(cat /opt/muos/config/brightness.txt)"
 if [ "$C_BRIGHT" -lt 1 ]; then
-	/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh U
+	/opt/muos/device/current/input/combo/bright.sh U
 else
-	/opt/muos/device/"$(GET_VAR "device" "board/name")"/input/combo/bright.sh "$C_BRIGHT"
+	/opt/muos/device/current/input/combo/bright.sh "$C_BRIGHT"
 fi
 
 GET_VAR "global" "settings/general/colour" >/sys/class/disp/disp/attr/color_temperature
 
 if [ "$(GET_VAR "global" "settings/general/hdmi")" -gt -1 ]; then
 	killall hdmi_start.sh
-	/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/hdmi_stop.sh
+	/opt/muos/device/current/script/hdmi_stop.sh
 	if [ "$(GET_VAR "device" "board/hdmi")" -eq 1 ]; then
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/hdmi_start.sh &
+		/opt/muos/device/current/script/hdmi_start.sh &
 	fi
 else
 	if pgrep -f "hdmi_start.sh" >/dev/null; then
 		killall hdmi_start.sh
-		/opt/muos/device/"$(GET_VAR "device" "board/name")"/script/hdmi_stop.sh
+		/opt/muos/device/current/script/hdmi_stop.sh
 	fi
 fi
 

--- a/script/system/suspend.sh
+++ b/script/system/suspend.sh
@@ -11,7 +11,7 @@ SLEEP() {
 
 	DEV_BOARD=$(GET_VAR "device" "board/name")
 	case "$DEV_BOARD" in
-		rg40xx*) /opt/muos/device/"$DEV_BOARD"/script/led_control.sh 1 0 0 0 0 0 0 0 ;;
+		rg40xx*) /opt/muos/device/current/script/led_control.sh 1 0 0 0 0 0 0 0 ;;
 		*) ;;
 	esac
 
@@ -34,7 +34,7 @@ RESUME() {
 			if [ -f "$RGBCONF_SCRIPT" ]; then
 				"$RGBCONF_SCRIPT"
 			else
-				/opt/muos/device/"$DEV_BOARD"/script/led_control.sh 1 0 0 0 0 0 0 0
+				/opt/muos/device/current/script/led_control.sh 1 0 0 0 0 0 0 0
 			fi
 			;;
 		*) ;;

--- a/theme/rgb/rgbconf.sh
+++ b/theme/rgb/rgbconf.sh
@@ -1,1 +1,1 @@
-/opt/muos/device/rg40xx-h/script/led_control.sh 1 76 225 173 1 225 173 1
+/opt/muos/device/current/script/led_control.sh 1 76 225 173 1 225 173 1


### PR DESCRIPTION
Generated with this ugly sed command:

```
git grep -Elz $'/opt/muos/device/"?\$\(GET_VAR "?device"? "?board/name"?\)"?' | xargs -0 sed -Ei $'s|/opt/muos/device/"?\$\(GET_VAR "?device"? "?board/name"?\)"?|/opt/muos/device/current|'
```

And then manually mopping up some more cases found via:

```
git grep -P '/opt/muos/device/(?!current)'
```

I left `script/var/init/system.sh` alone since it looks like that runs at the top of `startup.sh` _before_ we make the symlink.