### PR TITLE
Fix Sleep Shutdown w/ verbose messages enabled

### DIFF
--- a/script/mux/close_game.sh
+++ b/script/mux/close_game.sh
@@ -103,7 +103,7 @@ HALT_SYSTEM() {
 
 	# When "verbose messages" setting is enabled, run the underlying halt
 	# script in fbpad so its output is visible on screen.
-	if [ "$(GET_VAR "global" "settings/advanced/verbose")" -eq 1 ]; then
+	if [ "$HALT_SRC" = frontend ] && [ "$(GET_VAR "global" "settings/advanced/verbose")" -eq 1 ]; then
 		/opt/muos/bin/fbpad /opt/muos/script/system/halt.sh "$HALT_CMD" </dev/null
 	else
 		/opt/muos/script/system/halt.sh "$HALT_CMD"


### PR DESCRIPTION
When verbose messages are enabled, Sleep Shutdown is flaky in weird ways. For example, when triggered within RA, RA exits correctly, but the system doesn't shutdown.

I tracked it down to some sort of issue with fbpad. My guess is it gets unhappy if launched in parallel with some framebuffer resetting that happens after we exit RA, or something like that.

But really, it's a moot point because the screen is blanked for Sleep Shutdown anyway, so easy fix is just not to use fbpad in that case, regardless of verbose setting. :)