### PR TITLE
Add hotkeys for RGB control (thanks @JanTrueno!) & improve input.sh for muxcredits

### DIFF
--- a/device/rg28xx/input/input.sh
+++ b/device/rg28xx/input/input.sh
@@ -52,13 +52,7 @@ HANDLE_HOTKEY() {
 		VOL_DOWN) /opt/muos/device/current/input/combo/audio.sh D ;;
 
 		# Misc combos:
-		RETROWAIT_IGNORE)
-			[ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start"
-			# TODO: Add a handler for this in muxcredits instead.
-			if pgrep -f "muxcredits" >/dev/null; then
-				killall -q "muxcredits"
-			fi
-			;;
+		RETROWAIT_IGNORE) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start" ;;
 		RETROWAIT_MENU) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "menu" >"/tmp/net_start" ;;
 	esac
 }
@@ -68,7 +62,8 @@ MONITOR_FG_PROC() {
 	# prevent us from dimming the display or going to sleep.
 	while true; do
 		case "$(GET_VAR system foreground_process)" in
-			fbpad | muxcharge | muxstart) touch /run/muos/system/idle_inhibit ;;
+			# TODO: Use SET_VAR 0/1 instead of touch/rm.
+			fbpad | muxcharge | muxcredits | muxstart) touch /run/muos/system/idle_inhibit ;;
 			*) rm -f /run/muos/system/idle_inhibit ;;
 		esac
 		sleep 5

--- a/device/rg35xx-2024/input/input.sh
+++ b/device/rg35xx-2024/input/input.sh
@@ -52,13 +52,7 @@ HANDLE_HOTKEY() {
 		VOL_DOWN) /opt/muos/device/current/input/combo/audio.sh D ;;
 
 		# Misc combos:
-		RETROWAIT_IGNORE)
-			[ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start"
-			# TODO: Add a handler for this in muxcredits instead.
-			if pgrep -f "muxcredits" >/dev/null; then
-				killall -q "muxcredits"
-			fi
-			;;
+		RETROWAIT_IGNORE) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start" ;;
 		RETROWAIT_MENU) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "menu" >"/tmp/net_start" ;;
 	esac
 }
@@ -68,7 +62,8 @@ MONITOR_FG_PROC() {
 	# prevent us from dimming the display or going to sleep.
 	while true; do
 		case "$(GET_VAR system foreground_process)" in
-			fbpad | muxcharge | muxstart) touch /run/muos/system/idle_inhibit ;;
+			# TODO: Use SET_VAR 0/1 instead of touch/rm.
+			fbpad | muxcharge | muxcredits | muxstart) touch /run/muos/system/idle_inhibit ;;
 			*) rm -f /run/muos/system/idle_inhibit ;;
 		esac
 		sleep 5

--- a/device/rg35xx-h/input/input.sh
+++ b/device/rg35xx-h/input/input.sh
@@ -49,13 +49,7 @@ HANDLE_HOTKEY() {
 		VOL_DOWN) /opt/muos/device/current/input/combo/audio.sh D ;;
 
 		# Misc combos:
-		RETROWAIT_IGNORE)
-			[ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start"
-			# TODO: Add a handler for this in muxcredits instead.
-			if pgrep -f "muxcredits" >/dev/null; then
-				killall -q "muxcredits"
-			fi
-			;;
+		RETROWAIT_IGNORE) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start" ;;
 		RETROWAIT_MENU) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "menu" >"/tmp/net_start" ;;
 	esac
 }
@@ -65,7 +59,8 @@ MONITOR_FG_PROC() {
 	# prevent us from dimming the display or going to sleep.
 	while true; do
 		case "$(GET_VAR system foreground_process)" in
-			fbpad | muxcharge | muxstart) touch /run/muos/system/idle_inhibit ;;
+			# TODO: Use SET_VAR 0/1 instead of touch/rm.
+			fbpad | muxcharge | muxcredits | muxstart) touch /run/muos/system/idle_inhibit ;;
 			*) rm -f /run/muos/system/idle_inhibit ;;
 		esac
 		sleep 5

--- a/device/rg35xx-plus/input/input.sh
+++ b/device/rg35xx-plus/input/input.sh
@@ -52,13 +52,7 @@ HANDLE_HOTKEY() {
 		VOL_DOWN) /opt/muos/device/current/input/combo/audio.sh D ;;
 
 		# Misc combos:
-		RETROWAIT_IGNORE)
-			[ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start"
-			# TODO: Add a handler for this in muxcredits instead.
-			if pgrep -f "muxcredits" >/dev/null; then
-				killall -q "muxcredits"
-			fi
-			;;
+		RETROWAIT_IGNORE) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start" ;;
 		RETROWAIT_MENU) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "menu" >"/tmp/net_start" ;;
 	esac
 }
@@ -68,7 +62,8 @@ MONITOR_FG_PROC() {
 	# prevent us from dimming the display or going to sleep.
 	while true; do
 		case "$(GET_VAR system foreground_process)" in
-			fbpad | muxcharge | muxstart) touch /run/muos/system/idle_inhibit ;;
+			# TODO: Use SET_VAR 0/1 instead of touch/rm.
+			fbpad | muxcharge | muxcredits | muxstart) touch /run/muos/system/idle_inhibit ;;
 			*) rm -f /run/muos/system/idle_inhibit ;;
 		esac
 		sleep 5

--- a/device/rg35xx-sp/input/input.sh
+++ b/device/rg35xx-sp/input/input.sh
@@ -53,13 +53,7 @@ HANDLE_HOTKEY() {
 		VOL_DOWN) /opt/muos/device/current/input/combo/audio.sh D ;;
 
 		# Misc combos:
-		RETROWAIT_IGNORE)
-			[ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start"
-			# TODO: Add a handler for this in muxcredits instead.
-			if pgrep -f "muxcredits" >/dev/null; then
-				killall -q "muxcredits"
-			fi
-			;;
+		RETROWAIT_IGNORE) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start" ;;
 		RETROWAIT_MENU) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "menu" >"/tmp/net_start" ;;
 	esac
 }
@@ -69,7 +63,8 @@ MONITOR_FG_PROC() {
 	# prevent us from dimming the display or going to sleep.
 	while true; do
 		case "$(GET_VAR system foreground_process)" in
-			fbpad | muxcharge | muxstart) touch /run/muos/system/idle_inhibit ;;
+			# TODO: Use SET_VAR 0/1 instead of touch/rm.
+			fbpad | muxcharge | muxcredits | muxstart) touch /run/muos/system/idle_inhibit ;;
 			*) rm -f /run/muos/system/idle_inhibit ;;
 		esac
 		sleep 5

--- a/device/rg40xx-h/input/input.sh
+++ b/device/rg40xx-h/input/input.sh
@@ -14,6 +14,8 @@ READ_HOTKEYS() {
 	# Restart muhotkey if it exits. (tweak.sh kills it on config changes.)
 	# Order matters! Only the first matching combo will trigger.
 	while true; do
+		# Don't enable hold for RGB combos since rgbcli is a bit slow
+		# and allowing holds makes the input loop unresponsive.
 		/opt/muos/extra/muhotkey \
 			-C OSF=POWER_LONG+L1+L2+R1+R2 \
 			-C SLEEP=POWER_LONG \
@@ -22,6 +24,11 @@ READ_HOTKEYS() {
 			-H VOL_UP=VOL_UP \
 			-H BRIGHT_DOWN=VOL_DOWN+MENU_LONG \
 			-H VOL_DOWN=VOL_DOWN \
+			-C RGB_MODE=R3+MENU_LONG \
+			-C RGB_BRIGHT_UP=RS_UP+MENU_LONG \
+			-C RGB_BRIGHT_DOWN=RS_DOWN+MENU_LONG \
+			-C RGB_COLOR_PREV=RS_LEFT+MENU_LONG \
+			-C RGB_COLOR_NEXT=RS_RIGHT+MENU_LONG \
 			-C RETROWAIT_IGNORE=START \
 			-C RETROWAIT_MENU=SELECT
 	done
@@ -47,6 +54,13 @@ HANDLE_HOTKEY() {
 		VOL_UP) /opt/muos/device/current/input/combo/audio.sh U ;;
 		BRIGHT_DOWN) /opt/muos/device/current/input/combo/bright.sh D ;;
 		VOL_DOWN) /opt/muos/device/current/input/combo/audio.sh D ;;
+
+		# Stick combos:
+		RGB_MODE) RGB_CLI -m up ;;
+		RGB_BRIGHT_UP) RGB_CLI -b up ;;
+		RGB_BRIGHT_DOWN) RGB_CLI -b down ;;
+		RGB_COLOR_PREV) RGB_CLI -c down ;;
+		RGB_COLOR_NEXT) RGB_CLI -c up ;;
 
 		# Misc combos:
 		RETROWAIT_IGNORE)
@@ -111,6 +125,12 @@ SLEEP() {
 			fi
 			;;
 	esac
+}
+
+RGB_CLI() {
+	RGB_DIR="$(GET_VAR "device" "storage/rom/mount")/MUOS/application/.rgbcontroller"
+	LD_LIBRARY_PATH="$RGB_DIR/libs:$LD_LIBRARY_PATH" \
+		"$RGB_DIR/love" "$RGB_DIR/rgbcli" "$@"
 }
 
 mkdir -p /tmp/trigger

--- a/device/rg40xx-h/input/input.sh
+++ b/device/rg40xx-h/input/input.sh
@@ -63,13 +63,7 @@ HANDLE_HOTKEY() {
 		RGB_COLOR_NEXT) RGB_CLI -c up ;;
 
 		# Misc combos:
-		RETROWAIT_IGNORE)
-			[ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start"
-			# TODO: Add a handler for this in muxcredits instead.
-			if pgrep -f "muxcredits" >/dev/null; then
-				killall -q "muxcredits"
-			fi
-			;;
+		RETROWAIT_IGNORE) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start" ;;
 		RETROWAIT_MENU) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "menu" >"/tmp/net_start" ;;
 	esac
 }
@@ -79,7 +73,8 @@ MONITOR_FG_PROC() {
 	# prevent us from dimming the display or going to sleep.
 	while true; do
 		case "$(GET_VAR system foreground_process)" in
-			fbpad | muxcharge | muxstart) touch /run/muos/system/idle_inhibit ;;
+			# TODO: Use SET_VAR 0/1 instead of touch/rm.
+			fbpad | muxcharge | muxcredits | muxstart) touch /run/muos/system/idle_inhibit ;;
 			*) rm -f /run/muos/system/idle_inhibit ;;
 		esac
 		sleep 5

--- a/device/rg40xx-v/input/input.sh
+++ b/device/rg40xx-v/input/input.sh
@@ -63,13 +63,7 @@ HANDLE_HOTKEY() {
 		RGB_COLOR_NEXT) RGB_CLI -c up ;;
 
 		# Misc combos:
-		RETROWAIT_IGNORE)
-			[ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start"
-			# TODO: Add a handler for this in muxcredits instead.
-			if pgrep -f "muxcredits" >/dev/null; then
-				killall -q "muxcredits"
-			fi
-			;;
+		RETROWAIT_IGNORE) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start" ;;
 		RETROWAIT_MENU) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "menu" >"/tmp/net_start" ;;
 	esac
 }
@@ -79,7 +73,8 @@ MONITOR_FG_PROC() {
 	# prevent us from dimming the display or going to sleep.
 	while true; do
 		case "$(GET_VAR system foreground_process)" in
-			fbpad | muxcharge | muxstart) touch /run/muos/system/idle_inhibit ;;
+			# TODO: Use SET_VAR 0/1 instead of touch/rm.
+			fbpad | muxcharge | muxcredits | muxstart) touch /run/muos/system/idle_inhibit ;;
 			*) rm -f /run/muos/system/idle_inhibit ;;
 		esac
 		sleep 5

--- a/device/rg40xx-v/input/input.sh
+++ b/device/rg40xx-v/input/input.sh
@@ -14,6 +14,8 @@ READ_HOTKEYS() {
 	# Restart muhotkey if it exits. (tweak.sh kills it on config changes.)
 	# Order matters! Only the first matching combo will trigger.
 	while true; do
+		# Don't enable hold for RGB combos since rgbcli is a bit slow
+		# and allowing holds makes the input loop unresponsive.
 		/opt/muos/extra/muhotkey \
 			-C OSF=POWER_LONG+L1+L2+R1+R2 \
 			-C SLEEP=POWER_LONG \
@@ -22,6 +24,11 @@ READ_HOTKEYS() {
 			-H VOL_UP=VOL_UP \
 			-H BRIGHT_DOWN=VOL_DOWN+MENU_LONG \
 			-H VOL_DOWN=VOL_DOWN \
+			-C RGB_MODE=L3+MENU_LONG \
+			-C RGB_BRIGHT_UP=LS_UP+MENU_LONG \
+			-C RGB_BRIGHT_DOWN=LS_DOWN+MENU_LONG \
+			-C RGB_COLOR_PREV=LS_LEFT+MENU_LONG \
+			-C RGB_COLOR_NEXT=LS_RIGHT+MENU_LONG \
 			-C RETROWAIT_IGNORE=START \
 			-C RETROWAIT_MENU=SELECT
 	done
@@ -47,6 +54,13 @@ HANDLE_HOTKEY() {
 		VOL_UP) /opt/muos/device/current/input/combo/audio.sh U ;;
 		BRIGHT_DOWN) /opt/muos/device/current/input/combo/bright.sh D ;;
 		VOL_DOWN) /opt/muos/device/current/input/combo/audio.sh D ;;
+
+		# Stick combos:
+		RGB_MODE) RGB_CLI -m up ;;
+		RGB_BRIGHT_UP) RGB_CLI -b up ;;
+		RGB_BRIGHT_DOWN) RGB_CLI -b down ;;
+		RGB_COLOR_PREV) RGB_CLI -c down ;;
+		RGB_COLOR_NEXT) RGB_CLI -c up ;;
 
 		# Misc combos:
 		RETROWAIT_IGNORE)
@@ -111,6 +125,12 @@ SLEEP() {
 			fi
 			;;
 	esac
+}
+
+RGB_CLI() {
+	RGB_DIR="$(GET_VAR "device" "storage/rom/mount")/MUOS/application/.rgbcontroller"
+	LD_LIBRARY_PATH="$RGB_DIR/libs:$LD_LIBRARY_PATH" \
+		"$RGB_DIR/love" "$RGB_DIR/rgbcli" "$@"
 }
 
 mkdir -p /tmp/trigger

--- a/init/MUOS/application/.rgbcontroller/rgbcli/command.lua
+++ b/init/MUOS/application/.rgbcontroller/rgbcli/command.lua
@@ -63,7 +63,7 @@ function command.run(settings, colors, double_colors)
     print("Running command: /opt/muos/device/current/script/led_control.sh " .. commandArgs)
 
     -- Execute the command in the system shell
-    os.execute("/run/muos/storage/theme/active/rgb/rgbconf.sh")
+    os.execute("/mnt/mmc/MUOS/theme/active/rgb/rgbconf.sh")
 end
 
 return command

--- a/init/MUOS/application/.rgbcontroller/rgbcli/conf.lua
+++ b/init/MUOS/application/.rgbcontroller/rgbcli/conf.lua
@@ -1,0 +1,12 @@
+function love.conf(t)
+    t.console = true           -- Enable console output (useful for debugging in CLI mode)
+    t.modules.window = false    -- Disable the window module
+    t.modules.graphics = false  -- Disable the graphics module
+    t.modules.audio = false     -- Disable audio if not needed
+    t.modules.image = false     -- Disable image handling
+    t.modules.mouse = false     -- Disable mouse input
+    t.modules.touch = false     -- Disable touch input
+    t.modules.video = false     -- Disable video module
+    t.modules.thread = false    -- Disable threads if you aren't using them
+    t.window = nil              -- Remove window settings, as the window is disabled
+end

--- a/init/MUOS/application/.rgbcontroller/rgbcli/main.lua
+++ b/init/MUOS/application/.rgbcontroller/rgbcli/main.lua
@@ -1,0 +1,168 @@
+local command = require("command")
+local tables = require("tables")
+
+local modes = tables.modes
+local colors = tables.colors
+local settings = tables.settings
+local menu = tables.menu
+
+-- Load the settings from a file
+function loadSettings()
+    local filePath = "/mnt/mmc/MUOS/theme/active/rgb/settings.txt"
+    local file = io.open(filePath, "r")
+    
+    if file then
+        local contents = file:read("*all")
+        file:close()
+        
+        if contents then
+            parseSettings(contents)
+        else
+            print("Failed to read settings file.")
+        end
+    else
+        print("Settings file not found.")
+    end
+end
+
+-- Parse the settings from the file
+function parseSettings(contents)
+    for line in contents:gmatch("[^\r\n]+") do
+        local key, value = line:match("(%w+)=(%d+)")
+        if key and value then
+            settings[key] = tonumber(value)
+        end
+    end
+end
+
+-- Convert brightness from 1-10 to 0-255 scale
+local function convertBrightness(brightness)
+    return math.floor((brightness - 1) * 25.5)
+end
+
+-- Function to save the settings to a file
+local function saveSettings()
+    local settingsData = string.format(
+        "mode=%d\ncolor=%d\ncombo=%d\nbrightness=%d\nspeed=%d",
+        settings.mode,
+        settings.color,
+        settings.combo,
+        settings.brightness,
+        settings.speed
+    )
+    
+    local filePath = "/mnt/mmc/MUOS/theme/active/rgb/settings.txt"
+    local file = io.open(filePath, "w")
+    
+    if file then
+        file:write(settingsData)
+        file:close()
+    else
+        print("Failed to open file for writing.")
+    end
+end
+
+-- Helper function to adjust settings with or without wraparound
+local function changeSetting(currentValue, minValue, maxValue, direction, wraparound)
+    if direction == "up" then
+        currentValue = currentValue + 1
+        if currentValue > maxValue then
+            if wraparound then
+                currentValue = minValue  -- Wrap around to the start
+            else
+                currentValue = maxValue -- Stay at max value (no wraparound)
+            end
+        end
+    elseif direction == "down" then
+        currentValue = currentValue - 1
+        if currentValue < minValue then
+            if wraparound then
+                currentValue = maxValue -- Wrap around to the end
+            else
+                currentValue = minValue -- Stay at min value (no wraparound)
+            end
+        end
+    end
+    return currentValue
+end
+
+-- Function to handle command-line arguments
+local function handleCLIArgs(args)
+    -- Load settings before processing any arguments
+    loadSettings()
+
+    -- Map short flags to the actual commands
+    local flagToCommand = {
+        ["-b"] = "brightness",
+        ["-m"] = "mode",
+        ["-c"] = "color_or_combo",  -- Changed from "color" to "color_or_combo"
+        ["-s"] = "speed"  -- Removed -o flag
+    }
+
+    local commandTriggered = false
+
+    -- Define valid commands and the logic to update settings
+    local validCommands = {
+        ["mode"] = function(direction)
+            settings.mode = changeSetting(settings.mode, 1, #modes, direction, true)
+            print("Mode changed to " .. settings.mode)
+        end,
+        ["color_or_combo"] = function(direction)
+            -- Change color for modes 2-5, combo for mode 6
+            if settings.mode >= 2 and settings.mode <= 5 then
+                settings.color = changeSetting(settings.color, 1, #colors, direction, false)
+                print("Color changed to " .. settings.color)
+            elseif settings.mode == 6 then
+                settings.combo = changeSetting(settings.combo, 1, #tables.double_colors, direction, false)
+                print("Combo changed to " .. settings.combo)
+            end
+        end,
+        ["brightness"] = function(direction)
+            settings.brightness = changeSetting(settings.brightness, 1, 10, direction, false)  -- Brightness limited to 1-10
+            print("Brightness changed to " .. settings.brightness)
+        end,
+        ["speed"] = function(direction)
+            settings.speed = changeSetting(settings.speed, 1, 10, direction, true)  -- Speed wraps around
+            print("Speed changed to " .. settings.speed)
+        end
+    }
+
+    -- Validate that there are arguments and they are in pairs (flag and direction)
+    if (#args - 1) % 2 ~= 0 then
+        print("Error: Invalid number of arguments. Each flag must be followed by 'up' or 'down'.")
+        return
+    end
+
+    -- Start at index 2, because arg[1] is the path used to run the folder
+    for i = 2, #args, 2 do
+        local flag = args[i]
+        local direction = args[i + 1]
+
+        -- Ensure direction is valid
+        if direction == nil or (direction ~= "up" and direction ~= "down") then
+            print("Error: Invalid direction for flag '" .. flag .. "'. Use 'up' or 'down'.")
+            return
+        end
+
+        -- Map the flag to the actual command
+        local command = flagToCommand[flag]
+        if command and validCommands[command] then
+            validCommands[command](direction)
+            commandTriggered = true
+        else
+            print("Invalid flag: " .. tostring(flag))
+        end
+    end
+
+    -- Save settings if any command was triggered
+    if commandTriggered then
+        command.run(settings, colors, tables.double_colors)  -- Run the command with updated settings
+        saveSettings()  -- Save the updated settings
+        
+        love.event.quit()  -- Directly quit Love2D
+    end
+end
+
+
+-- Example: handleCLIArgs({ "./love", "-m", "up", "-c", "down" })
+handleCLIArgs(arg)  -- Pass the command-line arguments to the function

--- a/init/MUOS/application/.rgbcontroller/rgbcli/tables.lua
+++ b/init/MUOS/application/.rgbcontroller/rgbcli/tables.lua
@@ -1,0 +1,63 @@
+-- tables.lua
+
+local tables = {}
+
+tables.modes = {
+    "Off",                   
+    "Static", 
+    "Fast Breathing", 
+    "Med Breathing", 
+    "Slow Breathing",
+    "Static Combo",
+    "Mono Rainbow", 
+    "Multi Rainbow"
+}
+
+tables.colors = {
+    {name = "Red", rgb = {255, 0, 0}},
+    {name = "Hot Pink", rgb = {255, 20, 40}},
+    {name = "Pink", rgb = {190, 18, 80}},
+    {name = "Blossom", rgb = {255, 119, 168}},
+    {name = "Peach", rgb = {255, 157, 129}},  
+    {name = "Pastel Orange", rgb = {210, 105, 30}},       
+    {name = "Salmon", rgb = {171, 82, 54}},
+    {name = "Light Orange", rgb = {255, 87, 34}},
+    {name = "Orange", rgb = {255, 130, 0}},
+    {name = "Mustard", rgb = {225, 173, 1}},
+    {name = "Yellow", rgb = {255, 255, 0}},  
+    {name = "Olive", rgb = {128, 128, 0}}, 
+    {name = "Vanilla", rgb = {255, 236, 39}}, 
+    {name = "Lime Green", rgb = {168, 231, 46}},   
+    {name = "Pistachio", rgb = {50, 255, 50}},
+    {name = "Green", rgb = {0, 255, 0}},
+    {name = "Neon Green", rgb = {0, 228, 54}},
+    {name = "Neon Cyan", rgb = {0, 255, 255}},           
+    {name = "Light Blue", rgb = {64, 224, 208}},      
+    {name = "Sky Blue", rgb = {135, 206, 235}},   
+    {name = "Blue", rgb = {41, 173, 255}},
+    {name = "True Blue", rgb = {0, 0, 255}},          
+    {name = "Neon Purple", rgb = {128, 0, 255}},
+    {name = "Purple", rgb = {160, 32, 240}},      
+    {name = "Lavender", rgb = {131, 70, 156}},
+    {name = "White", rgb = {255, 255, 255}},     
+}
+
+tables.double_colors = {
+    {name = "Switch", rgb = {255, 0, 0, 0, 0, 255}}, 
+    {name = "Moo", rgb = {0, 0, 0, 255, 241, 232}},    
+    {name = "Melon", rgb = {255, 0, 5, 0, 255, 0}}, 
+    {name = "Neon", rgb = {255, 0, 30, 0, 228, 54}},
+	{name = "Tropical", rgb = {255, 69, 0, 0, 255, 0}},
+    {name = "Cotton Candy", rgb = {255, 236, 39, 255, 119, 168}}
+
+}
+
+tables.settings = {
+    mode = 1,         -- Off mode initially
+    color = 5,        -- Default color
+    combo = 1,
+    brightness = 7,   -- Scale of 1 to 10
+    speed = 2  -- Default speed (scale 1 to 10)
+}
+
+return tables


### PR DESCRIPTION
[Discussion thread on Discord](https://discord.com/channels/1152022492001603615/1291954701490720799)

Many thanks to @JanTrueno for adding a CLI version of the RGB control app to make this possible. :D

Current hotkey selection (can be changed of course):

| Combo | Action |
| - | - |
| Menu + Right Stick Click | Change mode |
| Menu + Right Stick Up | Increase brightness |
| Menu + Right Stick Down | Decrease brightness |
| Menu + Right Stick Left | Previous color |
| Menu + Right Stick Right | Next color |

Right Stick is used since it's hard to press Menu + Left Stick on the 40H. (The 40V only has one stick, which is technically the left, so it uses that instead.)

RGB mode cycles between the modes the app supports: off, static, fast breathing, med breathing, slow breathing, static combo, mono rainbow, multi rainbow.

I also removed the `input.sh` special case for `muxcredits` now that it handles a quit combo itself (https://github.com/MustardOS/frontend/pull/94). (Not related to the RGB stuff, but touches the same script.)