### PR TITLE
Improve input/idle handling

### DIFF
--- a/device/rg28xx/input/input.sh
+++ b/device/rg28xx/input/input.sh
@@ -65,6 +65,11 @@ MONITOR_IDLE_INHIBIT() {
 			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
 			*) IDLE_INHIBIT=0 ;;
 		esac
+		# evsieve grabs input devices for exclusive access, preventing muhotkey from detecting
+		# activity. Disable idle entirely while it's running.
+		if pgrep -x evsieve >/dev/null; then
+			IDLE_INHIBIT=1
+		fi
 		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
 		sleep 5
 	done

--- a/device/rg28xx/input/input.sh
+++ b/device/rg28xx/input/input.sh
@@ -57,15 +57,15 @@ HANDLE_HOTKEY() {
 	esac
 }
 
-MONITOR_FG_PROC() {
+MONITOR_IDLE_INHIBIT() {
 	# Monitor for specific programs that should inhibit idle timeout and
 	# prevent us from dimming the display or going to sleep.
 	while true; do
 		case "$(GET_VAR system foreground_process)" in
-			# TODO: Use SET_VAR 0/1 instead of touch/rm.
-			fbpad | muxcharge | muxcredits | muxstart) touch /run/muos/system/idle_inhibit ;;
-			*) rm -f /run/muos/system/idle_inhibit ;;
+			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
+			*) IDLE_INHIBIT=0 ;;
 		esac
+		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
 		sleep 5
 	done
 }
@@ -140,7 +140,7 @@ if [ "$(GET_VAR global boot/factory_reset)" -eq 0 ]; then
 	/opt/muos/device/current/input/trigger/sleep.sh &
 fi
 
-MONITOR_FG_PROC &
+MONITOR_IDLE_INHIBIT &
 
 READ_HOTKEYS | while read -r HOTKEY; do
 	# Don't respond to any hotkeys while in charge mode.

--- a/device/rg35xx-2024/input/input.sh
+++ b/device/rg35xx-2024/input/input.sh
@@ -65,6 +65,11 @@ MONITOR_IDLE_INHIBIT() {
 			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
 			*) IDLE_INHIBIT=0 ;;
 		esac
+		# evsieve grabs input devices for exclusive access, preventing muhotkey from detecting
+		# activity. Disable idle entirely while it's running.
+		if pgrep -x evsieve >/dev/null; then
+			IDLE_INHIBIT=1
+		fi
 		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
 		sleep 5
 	done

--- a/device/rg35xx-2024/input/input.sh
+++ b/device/rg35xx-2024/input/input.sh
@@ -57,15 +57,15 @@ HANDLE_HOTKEY() {
 	esac
 }
 
-MONITOR_FG_PROC() {
+MONITOR_IDLE_INHIBIT() {
 	# Monitor for specific programs that should inhibit idle timeout and
 	# prevent us from dimming the display or going to sleep.
 	while true; do
 		case "$(GET_VAR system foreground_process)" in
-			# TODO: Use SET_VAR 0/1 instead of touch/rm.
-			fbpad | muxcharge | muxcredits | muxstart) touch /run/muos/system/idle_inhibit ;;
-			*) rm -f /run/muos/system/idle_inhibit ;;
+			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
+			*) IDLE_INHIBIT=0 ;;
 		esac
+		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
 		sleep 5
 	done
 }
@@ -140,7 +140,7 @@ if [ "$(GET_VAR global boot/factory_reset)" -eq 0 ]; then
 	/opt/muos/device/current/input/trigger/sleep.sh &
 fi
 
-MONITOR_FG_PROC &
+MONITOR_IDLE_INHIBIT &
 
 READ_HOTKEYS | while read -r HOTKEY; do
 	# Don't respond to any hotkeys while in charge mode.

--- a/device/rg35xx-h/input/input.sh
+++ b/device/rg35xx-h/input/input.sh
@@ -54,15 +54,15 @@ HANDLE_HOTKEY() {
 	esac
 }
 
-MONITOR_FG_PROC() {
+MONITOR_IDLE_INHIBIT() {
 	# Monitor for specific programs that should inhibit idle timeout and
 	# prevent us from dimming the display or going to sleep.
 	while true; do
 		case "$(GET_VAR system foreground_process)" in
-			# TODO: Use SET_VAR 0/1 instead of touch/rm.
-			fbpad | muxcharge | muxcredits | muxstart) touch /run/muos/system/idle_inhibit ;;
-			*) rm -f /run/muos/system/idle_inhibit ;;
+			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
+			*) IDLE_INHIBIT=0 ;;
 		esac
+		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
 		sleep 5
 	done
 }
@@ -117,7 +117,7 @@ if [ "$(GET_VAR global boot/factory_reset)" -eq 0 ]; then
 	/opt/muos/device/current/input/trigger/sleep.sh &
 fi
 
-MONITOR_FG_PROC &
+MONITOR_IDLE_INHIBIT &
 
 READ_HOTKEYS | while read -r HOTKEY; do
 	# Don't respond to any hotkeys while in charge mode.

--- a/device/rg35xx-h/input/input.sh
+++ b/device/rg35xx-h/input/input.sh
@@ -62,6 +62,11 @@ MONITOR_IDLE_INHIBIT() {
 			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
 			*) IDLE_INHIBIT=0 ;;
 		esac
+		# evsieve grabs input devices for exclusive access, preventing muhotkey from detecting
+		# activity. Disable idle entirely while it's running.
+		if pgrep -x evsieve >/dev/null; then
+			IDLE_INHIBIT=1
+		fi
 		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
 		sleep 5
 	done

--- a/device/rg35xx-plus/input/input.sh
+++ b/device/rg35xx-plus/input/input.sh
@@ -65,6 +65,11 @@ MONITOR_IDLE_INHIBIT() {
 			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
 			*) IDLE_INHIBIT=0 ;;
 		esac
+		# evsieve grabs input devices for exclusive access, preventing muhotkey from detecting
+		# activity. Disable idle entirely while it's running.
+		if pgrep -x evsieve >/dev/null; then
+			IDLE_INHIBIT=1
+		fi
 		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
 		sleep 5
 	done

--- a/device/rg35xx-plus/input/input.sh
+++ b/device/rg35xx-plus/input/input.sh
@@ -57,15 +57,15 @@ HANDLE_HOTKEY() {
 	esac
 }
 
-MONITOR_FG_PROC() {
+MONITOR_IDLE_INHIBIT() {
 	# Monitor for specific programs that should inhibit idle timeout and
 	# prevent us from dimming the display or going to sleep.
 	while true; do
 		case "$(GET_VAR system foreground_process)" in
-			# TODO: Use SET_VAR 0/1 instead of touch/rm.
-			fbpad | muxcharge | muxcredits | muxstart) touch /run/muos/system/idle_inhibit ;;
-			*) rm -f /run/muos/system/idle_inhibit ;;
+			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
+			*) IDLE_INHIBIT=0 ;;
 		esac
+		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
 		sleep 5
 	done
 }
@@ -140,7 +140,7 @@ if [ "$(GET_VAR global boot/factory_reset)" -eq 0 ]; then
 	/opt/muos/device/current/input/trigger/sleep.sh &
 fi
 
-MONITOR_FG_PROC &
+MONITOR_IDLE_INHIBIT &
 
 READ_HOTKEYS | while read -r HOTKEY; do
 	# Don't respond to any hotkeys while in charge mode.

--- a/device/rg35xx-sp/input/input.sh
+++ b/device/rg35xx-sp/input/input.sh
@@ -58,15 +58,15 @@ HANDLE_HOTKEY() {
 	esac
 }
 
-MONITOR_FG_PROC() {
+MONITOR_IDLE_INHIBIT() {
 	# Monitor for specific programs that should inhibit idle timeout and
 	# prevent us from dimming the display or going to sleep.
 	while true; do
 		case "$(GET_VAR system foreground_process)" in
-			# TODO: Use SET_VAR 0/1 instead of touch/rm.
-			fbpad | muxcharge | muxcredits | muxstart) touch /run/muos/system/idle_inhibit ;;
-			*) rm -f /run/muos/system/idle_inhibit ;;
+			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
+			*) IDLE_INHIBIT=0 ;;
 		esac
+		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
 		sleep 5
 	done
 }
@@ -141,7 +141,7 @@ if [ "$(GET_VAR global boot/factory_reset)" -eq 0 ]; then
 	/opt/muos/device/current/input/trigger/sleep.sh &
 fi
 
-MONITOR_FG_PROC &
+MONITOR_IDLE_INHIBIT &
 
 READ_HOTKEYS | while read -r HOTKEY; do
 	# Don't respond to any hotkeys while in charge mode or with lid closed.

--- a/device/rg35xx-sp/input/input.sh
+++ b/device/rg35xx-sp/input/input.sh
@@ -66,6 +66,11 @@ MONITOR_IDLE_INHIBIT() {
 			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
 			*) IDLE_INHIBIT=0 ;;
 		esac
+		# evsieve grabs input devices for exclusive access, preventing muhotkey from detecting
+		# activity. Disable idle entirely while it's running.
+		if pgrep -x evsieve >/dev/null; then
+			IDLE_INHIBIT=1
+		fi
 		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
 		sleep 5
 	done

--- a/device/rg40xx-h/input/input.sh
+++ b/device/rg40xx-h/input/input.sh
@@ -68,15 +68,15 @@ HANDLE_HOTKEY() {
 	esac
 }
 
-MONITOR_FG_PROC() {
+MONITOR_IDLE_INHIBIT() {
 	# Monitor for specific programs that should inhibit idle timeout and
 	# prevent us from dimming the display or going to sleep.
 	while true; do
 		case "$(GET_VAR system foreground_process)" in
-			# TODO: Use SET_VAR 0/1 instead of touch/rm.
-			fbpad | muxcharge | muxcredits | muxstart) touch /run/muos/system/idle_inhibit ;;
-			*) rm -f /run/muos/system/idle_inhibit ;;
+			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
+			*) IDLE_INHIBIT=0 ;;
 		esac
+		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
 		sleep 5
 	done
 }
@@ -137,7 +137,7 @@ if [ "$(GET_VAR global boot/factory_reset)" -eq 0 ]; then
 	/opt/muos/device/current/input/trigger/sleep.sh &
 fi
 
-MONITOR_FG_PROC &
+MONITOR_IDLE_INHIBIT &
 
 READ_HOTKEYS | while read -r HOTKEY; do
 	# Don't respond to any hotkeys while in charge mode.

--- a/device/rg40xx-h/input/input.sh
+++ b/device/rg40xx-h/input/input.sh
@@ -76,6 +76,11 @@ MONITOR_IDLE_INHIBIT() {
 			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
 			*) IDLE_INHIBIT=0 ;;
 		esac
+		# evsieve grabs input devices for exclusive access, preventing muhotkey from detecting
+		# activity. Disable idle entirely while it's running.
+		if pgrep -x evsieve >/dev/null; then
+			IDLE_INHIBIT=1
+		fi
 		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
 		sleep 5
 	done

--- a/device/rg40xx-v/input/input.sh
+++ b/device/rg40xx-v/input/input.sh
@@ -68,15 +68,15 @@ HANDLE_HOTKEY() {
 	esac
 }
 
-MONITOR_FG_PROC() {
+MONITOR_IDLE_INHIBIT() {
 	# Monitor for specific programs that should inhibit idle timeout and
 	# prevent us from dimming the display or going to sleep.
 	while true; do
 		case "$(GET_VAR system foreground_process)" in
-			# TODO: Use SET_VAR 0/1 instead of touch/rm.
-			fbpad | muxcharge | muxcredits | muxstart) touch /run/muos/system/idle_inhibit ;;
-			*) rm -f /run/muos/system/idle_inhibit ;;
+			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
+			*) IDLE_INHIBIT=0 ;;
 		esac
+		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
 		sleep 5
 	done
 }
@@ -137,7 +137,7 @@ if [ "$(GET_VAR global boot/factory_reset)" -eq 0 ]; then
 	/opt/muos/device/current/input/trigger/sleep.sh &
 fi
 
-MONITOR_FG_PROC &
+MONITOR_IDLE_INHIBIT &
 
 READ_HOTKEYS | while read -r HOTKEY; do
 	# Don't respond to any hotkeys while in charge mode.

--- a/device/rg40xx-v/input/input.sh
+++ b/device/rg40xx-v/input/input.sh
@@ -76,6 +76,11 @@ MONITOR_IDLE_INHIBIT() {
 			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
 			*) IDLE_INHIBIT=0 ;;
 		esac
+		# evsieve grabs input devices for exclusive access, preventing muhotkey from detecting
+		# activity. Disable idle entirely while it's running.
+		if pgrep -x evsieve >/dev/null; then
+			IDLE_INHIBIT=1
+		fi
 		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
 		sleep 5
 	done

--- a/script/var/init/system.sh
+++ b/script/var/init/system.sh
@@ -16,3 +16,4 @@ export GLOBAL_CONFIG DBUS_SESSION_BUS_ADDRESS PIPEWIRE_RUNTIME_DIR XDG_RUNTIME_D
 
 mkdir -p "/run/muos/system"
 touch "/run/muos/system/foreground_process"
+echo 0 >"/run/muos/system/idle_inhibit"


### PR DESCRIPTION
Requires companion PR to be merged at the same time: https://github.com/MustardOS/frontend/pull/99

* Changes `/run/muos/system/idle_inhibit` to a normal "variable file" with values 0/1 instead of just checking file presence. Same effect, but is more consistent with other muOS flags in the filesystem.
* Inhibits idle when `evsieve` is running. Works around issue [reported on Discord](https://discord.com/channels/1152022492001603615/1161936003477536788/1292518561260245155) where the system idles in ScummVM even when input is active. (Of course, @antiKk's efforts to remove `evsieve` are the real fix, but for now, not idling seems better than idling while we should be active.)