### PR TITLE
Fix known bugs in RG35XX-SP lid sleep

### DIFF
--- a/device/rg28xx/input/trigger/power.sh
+++ b/device/rg28xx/input/trigger/power.sh
@@ -34,7 +34,7 @@ DEV_WAKE() {
 
 DEV_SLEEP() {
 	FG_PROC_VAL=$(GET_VAR "system" "foreground_process")
-	case "$(cat "$FG_PROC_VAL")" in
+	case "$FG_PROC_VAL" in
 		fbpad | muxcharge | muxstart) ;;
 		*)
 			echo "off" >"$TMP_POWER_LONG"

--- a/device/rg35xx-2024/input/trigger/power.sh
+++ b/device/rg35xx-2024/input/trigger/power.sh
@@ -34,7 +34,7 @@ DEV_WAKE() {
 
 DEV_SLEEP() {
 	FG_PROC_VAL=$(GET_VAR "system" "foreground_process")
-	case "$(cat "$FG_PROC_VAL")" in
+	case "$FG_PROC_VAL" in
 		fbpad | muxcharge | muxstart) ;;
 		*)
 			echo "off" >"$TMP_POWER_LONG"

--- a/device/rg35xx-h/input/trigger/power.sh
+++ b/device/rg35xx-h/input/trigger/power.sh
@@ -34,7 +34,7 @@ DEV_WAKE() {
 
 DEV_SLEEP() {
 	FG_PROC_VAL=$(GET_VAR "system" "foreground_process")
-	case "$(cat "$FG_PROC_VAL")" in
+	case "$FG_PROC_VAL" in
 		fbpad | muxcharge | muxstart) ;;
 		*)
 			echo "off" >"$TMP_POWER_LONG"

--- a/device/rg35xx-plus/input/trigger/power.sh
+++ b/device/rg35xx-plus/input/trigger/power.sh
@@ -34,7 +34,7 @@ DEV_WAKE() {
 
 DEV_SLEEP() {
 	FG_PROC_VAL=$(GET_VAR "system" "foreground_process")
-	case "$(cat "$FG_PROC_VAL")" in
+	case "$FG_PROC_VAL" in
 		fbpad | muxcharge | muxstart) ;;
 		*)
 			echo "off" >"$TMP_POWER_LONG"

--- a/device/rg35xx-sp/input/trigger/power.sh
+++ b/device/rg35xx-sp/input/trigger/power.sh
@@ -36,7 +36,7 @@ DEV_WAKE() {
 
 DEV_SLEEP() {
 	FG_PROC_VAL=$(GET_VAR "system" "foreground_process")
-	case "$(cat "$FG_PROC_VAL")" in
+	case "$FG_PROC_VAL" in
 		fbpad | muxcharge | muxstart) ;;
 		*)
 			echo "off" >"$TMP_POWER_LONG"

--- a/device/rg35xx-sp/input/trigger/power.sh
+++ b/device/rg35xx-sp/input/trigger/power.sh
@@ -2,6 +2,8 @@
 
 . /opt/muos/script/var/func.sh
 
+. /opt/muos/script/mux/close_game.sh
+
 TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 
 HALL_KEY="/sys/class/power_supply/axp2202-battery/hallkey"
@@ -72,11 +74,33 @@ while true; do
 
 	# power button OR lid closed
 	if { [ "$TMP_POWER_LONG_VAL" = "off" ] || [ "$HALL_KEY_VAL" = "0" ]; } && [ "$SLEEP_STATE_VAL" = "awake" ]; then
-		if pgrep -f "playbgm.sh" >/dev/null; then
-			pkill -STOP "playbgm.sh"
-			killall -q "mpg123"
-		fi
-		DEV_SLEEP
+		# HACK: We duplicate this logic from input.sh, but only for the
+		# SP. On other devices, power.sh only handles the "Sleep XXs +
+		# Shutdown" mode, and input.sh handles the other modes directly.
+		#
+		# But the SP's lid switch is read via a file (hallkey) that
+		# requires polling, whereas the input loop spends most of its
+		# time blocked waiting for evdev events. On the SP, power.sh
+		# handles *all* shutdown settings in response to lid close.
+		#
+		# We should move the hallkey polling elsewhere (into muhotkey?)
+		# and rework power.sh to only handle "soft sleep" again.
+		case "$(GET_VAR global settings/power/shutdown)" in
+			# Disabled:
+			-2) ;;
+			# Sleep Suspend:
+			-1) /opt/muos/script/system/suspend.sh power ;;
+			# Instant Shutdown:
+			2) HALT_SYSTEM sleep poweroff ;;
+			# Sleep XXs + Shutdown:
+			*)
+				if pgrep -f "playbgm.sh" >/dev/null; then
+					pkill -STOP "playbgm.sh"
+					killall -q "mpg123"
+				fi
+				DEV_SLEEP
+				;;
+		esac
 	fi
 
 	# power button with lid open

--- a/device/rg35xx-sp/input/trigger/power.sh
+++ b/device/rg35xx-sp/input/trigger/power.sh
@@ -95,8 +95,11 @@ while true; do
 		DEV_WAKE
 	fi
 
-	# update lid closed flag and sleep state when lid is closed
-	if [ "$HALL_KEY_VAL" = "0" ]; then
+	# update lid closed flag and sleep state when lid is closed and asleep
+	#
+	# this lets us track lid state transitions (not just current state) and
+	# only wake up on lid open if the lid was previously closed
+	if [ "$HALL_KEY_VAL" = "0" ] && [ "$SLEEP_STATE_VAL" != awake ]; then
 		echo "1" >"$LID_CLOSED_FLAG"
 		echo "sleep-closed" >"$SLEEP_STATE"
 	fi

--- a/device/rg40xx-h/input/trigger/power.sh
+++ b/device/rg40xx-h/input/trigger/power.sh
@@ -34,7 +34,7 @@ DEV_WAKE() {
 
 DEV_SLEEP() {
 	FG_PROC_VAL=$(GET_VAR "system" "foreground_process")
-	case "$(cat "$FG_PROC_VAL")" in
+	case "$FG_PROC_VAL" in
 		fbpad | muxcharge | muxstart) ;;
 		*)
 			echo "off" >"$TMP_POWER_LONG"

--- a/device/rg40xx-v/input/trigger/power.sh
+++ b/device/rg40xx-v/input/trigger/power.sh
@@ -34,7 +34,7 @@ DEV_WAKE() {
 
 DEV_SLEEP() {
 	FG_PROC_VAL=$(GET_VAR "system" "foreground_process")
-	case "$(cat "$FG_PROC_VAL")" in
+	case "$FG_PROC_VAL" in
 		fbpad | muxcharge | muxstart) ;;
 		*)
 			echo "off" >"$TMP_POWER_LONG"


### PR DESCRIPTION
Requires testing before merging since I don't have an SP, and hence can't really test the hallkey behavior. (I did test the new SP script on the 35H with a hardcoded `hallkey = 1` and verified it wasn't catastrophically broken, but faithfully testing the lid close cases wasn't possible for me.)

Fixes a few bugs with the RG35XX-SP lid sleep:

1. Closing the lid on charger screen (muxcharge) puts the device in a state where it's on but locked up and can only be fixed by a hard reset. (Recent-ish regression, [reported on Discord](https://discord.com/channels/1152022492001603615/1292988140939771925/1292988140939771925).)
2. Internally tracked sleep/wake sleep gets out of sync with reality when lid is closed _without_ going to sleep, preventing hotkeys from working and causing other weird behavior. (Bug revealed after fixing the above bug.)
3. Lid close doesn't do anything when in "Sleep Suspend" (e.g., suspend-to-RAM) mode. (As far as I can tell, this bug has existed as long as muOS has had suspend to RAM.)

See commit messages for detailed descriptions of what changed. Note that I'm not super thrilled with the duplication of code between `input.sh` and `power.sh` for the SP. As mentioned on Discord, I'd like muhotkey to poll the `hallkey` itself in the future and synthesize `LID_CLOSED` / `LID_OPENED` events for the state transitions so we can more closely align the power button and lid sleep codepaths. However, that's not a change I want to try and rush right before a major release, especially since I can't test it thoroughly myself. :D