### PR TITLE
Turn on work LED after booting from muxcharge

### DIFF
--- a/device/rg28xx/script/charge.sh
+++ b/device/rg28xx/script/charge.sh
@@ -16,4 +16,5 @@ if [ "$(cat "$(GET_VAR "device" "battery/boot_mode")")" -eq 1 ] && [ "$(GET_VAR 
 	fi
 
 	echo "performance" >"$(GET_VAR "device" "cpu/governor")"
+	echo 1 >"$(GET_VAR "device" "led/normal")"
 fi

--- a/device/rg35xx-2024/script/charge.sh
+++ b/device/rg35xx-2024/script/charge.sh
@@ -16,4 +16,5 @@ if [ "$(cat "$(GET_VAR "device" "battery/boot_mode")")" -eq 1 ] && [ "$(GET_VAR 
 	fi
 
 	echo "performance" >"$(GET_VAR "device" "cpu/governor")"
+	echo 1 >"$(GET_VAR "device" "led/normal")"
 fi

--- a/device/rg35xx-h/script/charge.sh
+++ b/device/rg35xx-h/script/charge.sh
@@ -16,4 +16,5 @@ if [ "$(cat "$(GET_VAR "device" "battery/boot_mode")")" -eq 1 ] && [ "$(GET_VAR 
 	fi
 
 	echo "performance" >"$(GET_VAR "device" "cpu/governor")"
+	echo 1 >"$(GET_VAR "device" "led/normal")"
 fi

--- a/device/rg35xx-plus/script/charge.sh
+++ b/device/rg35xx-plus/script/charge.sh
@@ -16,4 +16,5 @@ if [ "$(cat "$(GET_VAR "device" "battery/boot_mode")")" -eq 1 ] && [ "$(GET_VAR 
 	fi
 
 	echo "performance" >"$(GET_VAR "device" "cpu/governor")"
+	echo 1 >"$(GET_VAR "device" "led/normal")"
 fi

--- a/device/rg35xx-sp/script/charge.sh
+++ b/device/rg35xx-sp/script/charge.sh
@@ -16,4 +16,5 @@ if [ "$(cat "$(GET_VAR "device" "battery/boot_mode")")" -eq 1 ] && [ "$(GET_VAR 
 	fi
 
 	echo "performance" >"$(GET_VAR "device" "cpu/governor")"
+	echo 1 >"$(GET_VAR "device" "led/normal")"
 fi

--- a/device/rg40xx-h/script/charge.sh
+++ b/device/rg40xx-h/script/charge.sh
@@ -16,4 +16,5 @@ if [ "$(cat "$(GET_VAR "device" "battery/boot_mode")")" -eq 1 ] && [ "$(GET_VAR 
 	fi
 
 	echo "performance" >"$(GET_VAR "device" "cpu/governor")"
+	echo 1 >"$(GET_VAR "device" "led/normal")"
 fi

--- a/device/rg40xx-v/script/charge.sh
+++ b/device/rg40xx-v/script/charge.sh
@@ -16,4 +16,5 @@ if [ "$(cat "$(GET_VAR "device" "battery/boot_mode")")" -eq 1 ] && [ "$(GET_VAR 
 	fi
 
 	echo "performance" >"$(GET_VAR "device" "cpu/governor")"
+	echo 1 >"$(GET_VAR "device" "led/normal")"
 fi


### PR DESCRIPTION
Purely cosmetic, but a user on Discord pointed out that when the device starts in charge mode, the green power LED doesn't come on if it's fully booted and then the charger cable is disconnected.