### PR TITLE
Move suspend-to-RAM debounce timer into suspend.sh

### DIFF
--- a/device/rg28xx/input/input.sh
+++ b/device/rg28xx/input/input.sh
@@ -9,8 +9,6 @@ SLEEP_STATE_FILE=/tmp/sleep_state
 POWER_LONG_FILE=/tmp/trigger/POWER_LONG
 DPAD_FILE=/sys/class/power_supply/axp2202-battery/nds_pwrkey
 
-RESUME_UPTIME="$(UPTIME)"
-
 READ_HOTKEYS() {
 	# Restart muhotkey if it exits. (tweak.sh kills it on config changes.)
 	# Order matters! Only the first matching combo will trigger.
@@ -94,13 +92,12 @@ SLEEP() {
 		-2) ;;
 		# Sleep Suspend:
 		-1)
-			if [ "$(echo "$(UPTIME) - $RESUME_UPTIME >= .1" | bc)" -eq 1 ]; then
+			if [ "$(echo "$(UPTIME) - $(GET_VAR system resume_uptime) >= .1" | bc)" -eq 1 ]; then
 				# When the user wakes the device from the mem
 				# power state with a long press, we receive that
 				# event right after resuming. Avoid suspending
 				# again by ignoring power presses within 100ms.
 				/opt/muos/script/system/suspend.sh power
-				RESUME_UPTIME="$(UPTIME)"
 			fi
 			;;
 		# Instant Shutdown:

--- a/device/rg35xx-2024/input/input.sh
+++ b/device/rg35xx-2024/input/input.sh
@@ -9,8 +9,6 @@ SLEEP_STATE_FILE=/tmp/sleep_state
 POWER_LONG_FILE=/tmp/trigger/POWER_LONG
 DPAD_FILE=/sys/class/power_supply/axp2202-battery/nds_pwrkey
 
-RESUME_UPTIME="$(UPTIME)"
-
 READ_HOTKEYS() {
 	# Restart muhotkey if it exits. (tweak.sh kills it on config changes.)
 	# Order matters! Only the first matching combo will trigger.
@@ -94,13 +92,12 @@ SLEEP() {
 		-2) ;;
 		# Sleep Suspend:
 		-1)
-			if [ "$(echo "$(UPTIME) - $RESUME_UPTIME >= .1" | bc)" -eq 1 ]; then
+			if [ "$(echo "$(UPTIME) - $(GET_VAR system resume_uptime) >= .1" | bc)" -eq 1 ]; then
 				# When the user wakes the device from the mem
 				# power state with a long press, we receive that
 				# event right after resuming. Avoid suspending
 				# again by ignoring power presses within 100ms.
 				/opt/muos/script/system/suspend.sh power
-				RESUME_UPTIME="$(UPTIME)"
 			fi
 			;;
 		# Instant Shutdown:

--- a/device/rg35xx-h/input/input.sh
+++ b/device/rg35xx-h/input/input.sh
@@ -8,8 +8,6 @@ BRIGHT_FILE=/opt/muos/config/brightness.txt
 SLEEP_STATE_FILE=/tmp/sleep_state
 POWER_LONG_FILE=/tmp/trigger/POWER_LONG
 
-RESUME_UPTIME="$(UPTIME)"
-
 READ_HOTKEYS() {
 	# Restart muhotkey if it exits. (tweak.sh kills it on config changes.)
 	# Order matters! Only the first matching combo will trigger.
@@ -91,13 +89,12 @@ SLEEP() {
 		-2) ;;
 		# Sleep Suspend:
 		-1)
-			if [ "$(echo "$(UPTIME) - $RESUME_UPTIME >= .1" | bc)" -eq 1 ]; then
+			if [ "$(echo "$(UPTIME) - $(GET_VAR system resume_uptime) >= .1" | bc)" -eq 1 ]; then
 				# When the user wakes the device from the mem
 				# power state with a long press, we receive that
 				# event right after resuming. Avoid suspending
 				# again by ignoring power presses within 100ms.
 				/opt/muos/script/system/suspend.sh power
-				RESUME_UPTIME="$(UPTIME)"
 			fi
 			;;
 		# Instant Shutdown:

--- a/device/rg35xx-plus/input/input.sh
+++ b/device/rg35xx-plus/input/input.sh
@@ -9,8 +9,6 @@ SLEEP_STATE_FILE=/tmp/sleep_state
 POWER_LONG_FILE=/tmp/trigger/POWER_LONG
 DPAD_FILE=/sys/class/power_supply/axp2202-battery/nds_pwrkey
 
-RESUME_UPTIME="$(UPTIME)"
-
 READ_HOTKEYS() {
 	# Restart muhotkey if it exits. (tweak.sh kills it on config changes.)
 	# Order matters! Only the first matching combo will trigger.
@@ -94,13 +92,12 @@ SLEEP() {
 		-2) ;;
 		# Sleep Suspend:
 		-1)
-			if [ "$(echo "$(UPTIME) - $RESUME_UPTIME >= .1" | bc)" -eq 1 ]; then
+			if [ "$(echo "$(UPTIME) - $(GET_VAR system resume_uptime) >= .1" | bc)" -eq 1 ]; then
 				# When the user wakes the device from the mem
 				# power state with a long press, we receive that
 				# event right after resuming. Avoid suspending
 				# again by ignoring power presses within 100ms.
 				/opt/muos/script/system/suspend.sh power
-				RESUME_UPTIME="$(UPTIME)"
 			fi
 			;;
 		# Instant Shutdown:

--- a/device/rg35xx-sp/input/input.sh
+++ b/device/rg35xx-sp/input/input.sh
@@ -10,8 +10,6 @@ POWER_LONG_FILE=/tmp/trigger/POWER_LONG
 DPAD_FILE=/sys/class/power_supply/axp2202-battery/nds_pwrkey
 HALL_KEY_FILE=/sys/class/power_supply/axp2202-battery/hallkey
 
-RESUME_UPTIME="$(UPTIME)"
-
 READ_HOTKEYS() {
 	# Restart muhotkey if it exits. (tweak.sh kills it on config changes.)
 	# Order matters! Only the first matching combo will trigger.
@@ -95,13 +93,12 @@ SLEEP() {
 		-2) ;;
 		# Sleep Suspend:
 		-1)
-			if [ "$(echo "$(UPTIME) - $RESUME_UPTIME >= .1" | bc)" -eq 1 ]; then
+			if [ "$(echo "$(UPTIME) - $(GET_VAR system resume_uptime) >= .1" | bc)" -eq 1 ]; then
 				# When the user wakes the device from the mem
 				# power state with a long press, we receive that
 				# event right after resuming. Avoid suspending
 				# again by ignoring power presses within 100ms.
 				/opt/muos/script/system/suspend.sh power
-				RESUME_UPTIME="$(UPTIME)"
 			fi
 			;;
 		# Instant Shutdown:

--- a/device/rg40xx-h/input/input.sh
+++ b/device/rg40xx-h/input/input.sh
@@ -11,8 +11,6 @@ POWER_LONG_FILE=/tmp/trigger/POWER_LONG
 RGBCONTROLLER_DIR="$(GET_VAR "device" "storage/rom/mount")/MUOS/application/.rgbcontroller"
 RGBCONF_SCRIPT=/run/muos/storage/theme/active/rgb/rgbconf.sh
 
-RESUME_UPTIME="$(UPTIME)"
-
 READ_HOTKEYS() {
 	# Restart muhotkey if it exits. (tweak.sh kills it on config changes.)
 	# Order matters! Only the first matching combo will trigger.
@@ -110,13 +108,12 @@ SLEEP() {
 		-2) ;;
 		# Sleep Suspend:
 		-1)
-			if [ "$(echo "$(UPTIME) - $RESUME_UPTIME >= .1" | bc)" -eq 1 ]; then
+			if [ "$(echo "$(UPTIME) - $(GET_VAR system resume_uptime) >= .1" | bc)" -eq 1 ]; then
 				# When the user wakes the device from the mem
 				# power state with a long press, we receive that
 				# event right after resuming. Avoid suspending
 				# again by ignoring power presses within 100ms.
 				/opt/muos/script/system/suspend.sh power
-				RESUME_UPTIME="$(UPTIME)"
 			fi
 			;;
 		# Instant Shutdown:

--- a/device/rg40xx-v/input/input.sh
+++ b/device/rg40xx-v/input/input.sh
@@ -11,8 +11,6 @@ POWER_LONG_FILE=/tmp/trigger/POWER_LONG
 RGBCONTROLLER_DIR="$(GET_VAR "device" "storage/rom/mount")/MUOS/application/.rgbcontroller"
 RGBCONF_SCRIPT=/run/muos/storage/theme/active/rgb/rgbconf.sh
 
-RESUME_UPTIME="$(UPTIME)"
-
 READ_HOTKEYS() {
 	# Restart muhotkey if it exits. (tweak.sh kills it on config changes.)
 	# Order matters! Only the first matching combo will trigger.
@@ -110,13 +108,12 @@ SLEEP() {
 		-2) ;;
 		# Sleep Suspend:
 		-1)
-			if [ "$(echo "$(UPTIME) - $RESUME_UPTIME >= .1" | bc)" -eq 1 ]; then
+			if [ "$(echo "$(UPTIME) - $(GET_VAR system resume_uptime) >= .1" | bc)" -eq 1 ]; then
 				# When the user wakes the device from the mem
 				# power state with a long press, we receive that
 				# event right after resuming. Avoid suspending
 				# again by ignoring power presses within 100ms.
 				/opt/muos/script/system/suspend.sh power
-				RESUME_UPTIME="$(UPTIME)"
 			fi
 			;;
 		# Instant Shutdown:

--- a/script/system/suspend.sh
+++ b/script/system/suspend.sh
@@ -55,6 +55,7 @@ case "$1" in
 		GET_VAR "global" "settings/advanced/state" >"/sys/power/state"
 		sleep 0.1
 		RESUME
+		SET_VAR "system" "resume_uptime" "$(UPTIME)"
 		;;
 	sleep)
 		for PROC in $SUSPEND_PROC; do

--- a/script/var/init/system.sh
+++ b/script/var/init/system.sh
@@ -17,3 +17,4 @@ export GLOBAL_CONFIG DBUS_SESSION_BUS_ADDRESS PIPEWIRE_RUNTIME_DIR XDG_RUNTIME_D
 mkdir -p "/run/muos/system"
 touch "/run/muos/system/foreground_process"
 echo 0 >"/run/muos/system/idle_inhibit"
+echo 0 >"/run/muos/system/resume_uptime"


### PR DESCRIPTION
Since we're (temporarily?) calling suspend.sh from multiple locations, we should set the resume time centrally so that the resume debounce works when suspending via SP lid close and resuming via power button.