### PR TITLE
Hide SD2 folder in MTP when SD2 isn't mounted

### DIFF
--- a/script/system/usb.sh
+++ b/script/system/usb.sh
@@ -80,6 +80,14 @@ START() {
 }
 
 UPDATE_UMTPRD_CONF() {
+	# Hide SD2 folder if unmounted. Checking here doesn't handle the user
+	# (un)plugging SD2 with the device running, but that's likely uncommon.
+	if [ "$(GET_VAR "device" "storage/sdcard/active")" -eq 1 ]; then
+		sed 's|^#storage "/mnt/sdcard"|storage "/mnt/sdcard"|' -i /etc/umtprd/umtprd.conf
+	else
+		sed 's|^storage "/mnt/sdcard"|#storage "/mnt/sdcard"|' -i /etc/umtprd/umtprd.conf
+	fi
+
 	sed \
 		-e "s/^usb_vendor_id .*/usb_vendor_id \"$(USB_VID)\"/" \
 		-e "s/^usb_product_id .*/usb_product_id \"$(USB_PID)\"/" \


### PR DESCRIPTION
Otherwise, we show the empty mountpoint directory and let folks accidentally dump files into the rootfs, which is probably not ideal.

It would be better to tie this in with the (un)plug detection in `sdcard.sh`, since umtprd seems to allow showing/hiding folders at runtime. But this is quick and easy by far the most common case (booting w/o an SD2 card).