### PR TITLE
Fix swapped controls for standalone PPSSPP

### DIFF
--- a/init/MUOS/application/PPSSPP.sh
+++ b/init/MUOS/application/PPSSPP.sh
@@ -32,7 +32,7 @@ esac
 
 sed -i '/^GraphicsBackend\|^FailedGraphicsBackends\|^DisabledGraphicsBackends/d' "$PPSSPP_DIR/.config/ppsspp/PSP/SYSTEM/ppsspp.ini"
 
-SDL_ASSERT=always_ignore SDL_GAMECONTROLLERCONFIG=$(grep "Deeplay" "/usr/lib/gamecontrollerdb.txt") ./PPSSPP
+SDL_ASSERT=always_ignore SDL_GAMECONTROLLERCONFIG=$(grep "Deeplay" "/opt/muos/device/current/control/gamecontrollerdb_retro.txt") ./PPSSPP
 
 case "$(GET_VAR "device" "board/name")" in
 	rg*)


### PR DESCRIPTION
Same as #308, but for PPSSPP launched "standalone" from the Applications menu rather than from the content explorer.