### PR TITLE
Inhibit idle during ffplay video playback

### DIFF
--- a/device/rg28xx/input/input.sh
+++ b/device/rg28xx/input/input.sh
@@ -3,6 +3,7 @@
 . /opt/muos/script/var/func.sh
 
 . /opt/muos/script/mux/close_game.sh
+. /opt/muos/script/mux/idle.sh
 
 BRIGHT_FILE=/opt/muos/config/brightness.txt
 SLEEP_STATE_FILE=/tmp/sleep_state
@@ -53,37 +54,6 @@ HANDLE_HOTKEY() {
 		RETROWAIT_IGNORE) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start" ;;
 		RETROWAIT_MENU) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "menu" >"/tmp/net_start" ;;
 	esac
-}
-
-MONITOR_IDLE_INHIBIT() {
-	# Monitor for specific programs that should inhibit idle timeout and
-	# prevent us from dimming the display or going to sleep.
-	while true; do
-		case "$(GET_VAR system foreground_process)" in
-			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
-			*) IDLE_INHIBIT=0 ;;
-		esac
-		# evsieve grabs input devices for exclusive access, preventing muhotkey from detecting
-		# activity. Disable idle entirely while it's running.
-		if pgrep -x evsieve >/dev/null; then
-			IDLE_INHIBIT=1
-		fi
-		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
-		sleep 5
-	done
-}
-
-DISPLAY_IDLE() {
-	if [ "$(DISPLAY_READ lcd0 getbl)" -gt 10 ]; then
-		DISPLAY_WRITE lcd0 setbl 10
-	fi
-}
-
-DISPLAY_ACTIVE() {
-	BL="$(cat "$BRIGHT_FILE")"
-	if [ "$(DISPLAY_READ lcd0 getbl)" -ne "$BL" ]; then
-		DISPLAY_WRITE lcd0 setbl "$BL"
-	fi
 }
 
 SLEEP() {
@@ -141,8 +111,6 @@ if [ "$(GET_VAR global boot/factory_reset)" -eq 0 ]; then
 	/opt/muos/device/current/input/trigger/power.sh &
 	/opt/muos/device/current/input/trigger/sleep.sh &
 fi
-
-MONITOR_IDLE_INHIBIT &
 
 READ_HOTKEYS | while read -r HOTKEY; do
 	# Don't respond to any hotkeys while in charge mode.

--- a/device/rg35xx-2024/input/input.sh
+++ b/device/rg35xx-2024/input/input.sh
@@ -3,6 +3,7 @@
 . /opt/muos/script/var/func.sh
 
 . /opt/muos/script/mux/close_game.sh
+. /opt/muos/script/mux/idle.sh
 
 BRIGHT_FILE=/opt/muos/config/brightness.txt
 SLEEP_STATE_FILE=/tmp/sleep_state
@@ -53,37 +54,6 @@ HANDLE_HOTKEY() {
 		RETROWAIT_IGNORE) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start" ;;
 		RETROWAIT_MENU) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "menu" >"/tmp/net_start" ;;
 	esac
-}
-
-MONITOR_IDLE_INHIBIT() {
-	# Monitor for specific programs that should inhibit idle timeout and
-	# prevent us from dimming the display or going to sleep.
-	while true; do
-		case "$(GET_VAR system foreground_process)" in
-			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
-			*) IDLE_INHIBIT=0 ;;
-		esac
-		# evsieve grabs input devices for exclusive access, preventing muhotkey from detecting
-		# activity. Disable idle entirely while it's running.
-		if pgrep -x evsieve >/dev/null; then
-			IDLE_INHIBIT=1
-		fi
-		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
-		sleep 5
-	done
-}
-
-DISPLAY_IDLE() {
-	if [ "$(DISPLAY_READ lcd0 getbl)" -gt 10 ]; then
-		DISPLAY_WRITE lcd0 setbl 10
-	fi
-}
-
-DISPLAY_ACTIVE() {
-	BL="$(cat "$BRIGHT_FILE")"
-	if [ "$(DISPLAY_READ lcd0 getbl)" -ne "$BL" ]; then
-		DISPLAY_WRITE lcd0 setbl "$BL"
-	fi
 }
 
 SLEEP() {
@@ -141,8 +111,6 @@ if [ "$(GET_VAR global boot/factory_reset)" -eq 0 ]; then
 	/opt/muos/device/current/input/trigger/power.sh &
 	/opt/muos/device/current/input/trigger/sleep.sh &
 fi
-
-MONITOR_IDLE_INHIBIT &
 
 READ_HOTKEYS | while read -r HOTKEY; do
 	# Don't respond to any hotkeys while in charge mode.

--- a/device/rg35xx-plus/input/input.sh
+++ b/device/rg35xx-plus/input/input.sh
@@ -3,6 +3,7 @@
 . /opt/muos/script/var/func.sh
 
 . /opt/muos/script/mux/close_game.sh
+. /opt/muos/script/mux/idle.sh
 
 BRIGHT_FILE=/opt/muos/config/brightness.txt
 SLEEP_STATE_FILE=/tmp/sleep_state
@@ -53,37 +54,6 @@ HANDLE_HOTKEY() {
 		RETROWAIT_IGNORE) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start" ;;
 		RETROWAIT_MENU) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "menu" >"/tmp/net_start" ;;
 	esac
-}
-
-MONITOR_IDLE_INHIBIT() {
-	# Monitor for specific programs that should inhibit idle timeout and
-	# prevent us from dimming the display or going to sleep.
-	while true; do
-		case "$(GET_VAR system foreground_process)" in
-			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
-			*) IDLE_INHIBIT=0 ;;
-		esac
-		# evsieve grabs input devices for exclusive access, preventing muhotkey from detecting
-		# activity. Disable idle entirely while it's running.
-		if pgrep -x evsieve >/dev/null; then
-			IDLE_INHIBIT=1
-		fi
-		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
-		sleep 5
-	done
-}
-
-DISPLAY_IDLE() {
-	if [ "$(DISPLAY_READ lcd0 getbl)" -gt 10 ]; then
-		DISPLAY_WRITE lcd0 setbl 10
-	fi
-}
-
-DISPLAY_ACTIVE() {
-	BL="$(cat "$BRIGHT_FILE")"
-	if [ "$(DISPLAY_READ lcd0 getbl)" -ne "$BL" ]; then
-		DISPLAY_WRITE lcd0 setbl "$BL"
-	fi
 }
 
 SLEEP() {
@@ -141,8 +111,6 @@ if [ "$(GET_VAR global boot/factory_reset)" -eq 0 ]; then
 	/opt/muos/device/current/input/trigger/power.sh &
 	/opt/muos/device/current/input/trigger/sleep.sh &
 fi
-
-MONITOR_IDLE_INHIBIT &
 
 READ_HOTKEYS | while read -r HOTKEY; do
 	# Don't respond to any hotkeys while in charge mode.

--- a/device/rg35xx-sp/input/input.sh
+++ b/device/rg35xx-sp/input/input.sh
@@ -3,6 +3,7 @@
 . /opt/muos/script/var/func.sh
 
 . /opt/muos/script/mux/close_game.sh
+. /opt/muos/script/mux/idle.sh
 
 BRIGHT_FILE=/opt/muos/config/brightness.txt
 SLEEP_STATE_FILE=/tmp/sleep_state
@@ -54,37 +55,6 @@ HANDLE_HOTKEY() {
 		RETROWAIT_IGNORE) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "ignore" >"/tmp/net_start" ;;
 		RETROWAIT_MENU) [ "$(GET_VAR global settings/advanced/retrowait)" -eq 1 ] && printf "menu" >"/tmp/net_start" ;;
 	esac
-}
-
-MONITOR_IDLE_INHIBIT() {
-	# Monitor for specific programs that should inhibit idle timeout and
-	# prevent us from dimming the display or going to sleep.
-	while true; do
-		case "$(GET_VAR system foreground_process)" in
-			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
-			*) IDLE_INHIBIT=0 ;;
-		esac
-		# evsieve grabs input devices for exclusive access, preventing muhotkey from detecting
-		# activity. Disable idle entirely while it's running.
-		if pgrep -x evsieve >/dev/null; then
-			IDLE_INHIBIT=1
-		fi
-		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
-		sleep 5
-	done
-}
-
-DISPLAY_IDLE() {
-	if [ "$(DISPLAY_READ lcd0 getbl)" -gt 10 ]; then
-		DISPLAY_WRITE lcd0 setbl 10
-	fi
-}
-
-DISPLAY_ACTIVE() {
-	BL="$(cat "$BRIGHT_FILE")"
-	if [ "$(DISPLAY_READ lcd0 getbl)" -ne "$BL" ]; then
-		DISPLAY_WRITE lcd0 setbl "$BL"
-	fi
 }
 
 SLEEP() {
@@ -142,8 +112,6 @@ if [ "$(GET_VAR global boot/factory_reset)" -eq 0 ]; then
 	/opt/muos/device/current/input/trigger/power.sh &
 	/opt/muos/device/current/input/trigger/sleep.sh &
 fi
-
-MONITOR_IDLE_INHIBIT &
 
 READ_HOTKEYS | while read -r HOTKEY; do
 	# Don't respond to any hotkeys while in charge mode or with lid closed.

--- a/device/rg40xx-h/input/input.sh
+++ b/device/rg40xx-h/input/input.sh
@@ -3,13 +3,13 @@
 . /opt/muos/script/var/func.sh
 
 . /opt/muos/script/mux/close_game.sh
+. /opt/muos/script/mux/idle.sh
 
 BRIGHT_FILE=/opt/muos/config/brightness.txt
 SLEEP_STATE_FILE=/tmp/sleep_state
 POWER_LONG_FILE=/tmp/trigger/POWER_LONG
 
 RGBCONTROLLER_DIR="$(GET_VAR "device" "storage/rom/mount")/MUOS/application/.rgbcontroller"
-RGBCONF_SCRIPT=/run/muos/storage/theme/active/rgb/rgbconf.sh
 
 READ_HOTKEYS() {
 	# Restart muhotkey if it exits. (tweak.sh kills it on config changes.)
@@ -69,39 +69,6 @@ HANDLE_HOTKEY() {
 	esac
 }
 
-MONITOR_IDLE_INHIBIT() {
-	# Monitor for specific programs that should inhibit idle timeout and
-	# prevent us from dimming the display or going to sleep.
-	while true; do
-		case "$(GET_VAR system foreground_process)" in
-			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
-			*) IDLE_INHIBIT=0 ;;
-		esac
-		# evsieve grabs input devices for exclusive access, preventing muhotkey from detecting
-		# activity. Disable idle entirely while it's running.
-		if pgrep -x evsieve >/dev/null; then
-			IDLE_INHIBIT=1
-		fi
-		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
-		sleep 5
-	done
-}
-
-DISPLAY_IDLE() {
-	if [ "$(DISPLAY_READ lcd0 getbl)" -gt 10 ]; then
-		DISPLAY_WRITE lcd0 setbl 10
-	fi
-	/opt/muos/device/current/script/led_control.sh 1 0 0 0 0 0 0 0
-}
-
-DISPLAY_ACTIVE() {
-	BL="$(cat "$BRIGHT_FILE")"
-	if [ "$(DISPLAY_READ lcd0 getbl)" -ne "$BL" ]; then
-		DISPLAY_WRITE lcd0 setbl "$BL"
-	fi
-	[ -x "$RGBCONF_SCRIPT" ] && "$RGBCONF_SCRIPT"
-}
-
 SLEEP() {
 	case "$(GET_VAR global settings/power/shutdown)" in
 		# Disabled:
@@ -142,8 +109,6 @@ if [ "$(GET_VAR global boot/factory_reset)" -eq 0 ]; then
 	/opt/muos/device/current/input/trigger/power.sh &
 	/opt/muos/device/current/input/trigger/sleep.sh &
 fi
-
-MONITOR_IDLE_INHIBIT &
 
 READ_HOTKEYS | while read -r HOTKEY; do
 	# Don't respond to any hotkeys while in charge mode.

--- a/device/rg40xx-v/input/input.sh
+++ b/device/rg40xx-v/input/input.sh
@@ -3,6 +3,7 @@
 . /opt/muos/script/var/func.sh
 
 . /opt/muos/script/mux/close_game.sh
+. /opt/muos/script/mux/idle.sh
 
 BRIGHT_FILE=/opt/muos/config/brightness.txt
 SLEEP_STATE_FILE=/tmp/sleep_state
@@ -69,39 +70,6 @@ HANDLE_HOTKEY() {
 	esac
 }
 
-MONITOR_IDLE_INHIBIT() {
-	# Monitor for specific programs that should inhibit idle timeout and
-	# prevent us from dimming the display or going to sleep.
-	while true; do
-		case "$(GET_VAR system foreground_process)" in
-			fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
-			*) IDLE_INHIBIT=0 ;;
-		esac
-		# evsieve grabs input devices for exclusive access, preventing muhotkey from detecting
-		# activity. Disable idle entirely while it's running.
-		if pgrep -x evsieve >/dev/null; then
-			IDLE_INHIBIT=1
-		fi
-		SET_VAR system idle_inhibit "$IDLE_INHIBIT"
-		sleep 5
-	done
-}
-
-DISPLAY_IDLE() {
-	if [ "$(DISPLAY_READ lcd0 getbl)" -gt 10 ]; then
-		DISPLAY_WRITE lcd0 setbl 10
-	fi
-	/opt/muos/device/current/script/led_control.sh 1 0 0 0 0 0 0 0
-}
-
-DISPLAY_ACTIVE() {
-	BL="$(cat "$BRIGHT_FILE")"
-	if [ "$(DISPLAY_READ lcd0 getbl)" -ne "$BL" ]; then
-		DISPLAY_WRITE lcd0 setbl "$BL"
-	fi
-	[ -x "$RGBCONF_SCRIPT" ] && "$RGBCONF_SCRIPT"
-}
-
 SLEEP() {
 	case "$(GET_VAR global settings/power/shutdown)" in
 		# Disabled:
@@ -142,8 +110,6 @@ if [ "$(GET_VAR global boot/factory_reset)" -eq 0 ]; then
 	/opt/muos/device/current/input/trigger/power.sh &
 	/opt/muos/device/current/input/trigger/sleep.sh &
 fi
-
-MONITOR_IDLE_INHIBIT &
 
 READ_HOTKEYS | while read -r HOTKEY; do
 	# Don't respond to any hotkeys while in charge mode.

--- a/script/mux/idle.sh
+++ b/script/mux/idle.sh
@@ -31,11 +31,6 @@ while true; do
 		fbpad | ffplay | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
 		*) IDLE_INHIBIT=0 ;;
 	esac
-	# evsieve grabs input devices for exclusive access, preventing muhotkey
-	# from detecting activity. Disable idle entirely while it's running.
-	if pgrep -x evsieve >/dev/null; then
-		IDLE_INHIBIT=1
-	fi
 	SET_VAR system idle_inhibit "$IDLE_INHIBIT"
 	sleep 5
 done &

--- a/script/mux/idle.sh
+++ b/script/mux/idle.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+. /opt/muos/script/var/func.sh
+
+LED_CONTROL=/opt/muos/device/current/script/led_control.sh
+RGBCONF=/run/muos/storage/theme/active/rgb/rgbconf.sh
+
+DISPLAY_IDLE() {
+	if [ "$(DISPLAY_READ lcd0 getbl)" -gt 10 ]; then
+		DISPLAY_WRITE lcd0 setbl 10
+	fi
+	case "$(GET_VAR device board/name)" in
+		rg40xx*) "$LED_CONTROL" 1 0 0 0 0 0 0 0 ;;
+	esac
+}
+
+DISPLAY_ACTIVE() {
+	BL="$(cat "$BRIGHT_FILE")"
+	if [ "$(DISPLAY_READ lcd0 getbl)" -ne "$BL" ]; then
+		DISPLAY_WRITE lcd0 setbl "$BL"
+	fi
+	case "$(GET_VAR device board/name)" in
+		rg40xx*) [ -x "$RGBCONF" ] && "$RGBCONF" ;;
+	esac
+}
+
+# Monitor for specific programs that should inhibit idle timeout and prevent us
+# from dimming the display or going to sleep.
+while true; do
+	case "$(GET_VAR system foreground_process)" in
+		fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
+		*) IDLE_INHIBIT=0 ;;
+	esac
+	# evsieve grabs input devices for exclusive access, preventing muhotkey
+	# from detecting activity. Disable idle entirely while it's running.
+	if pgrep -x evsieve >/dev/null; then
+		IDLE_INHIBIT=1
+	fi
+	SET_VAR system idle_inhibit "$IDLE_INHIBIT"
+	sleep 5
+done &

--- a/script/mux/idle.sh
+++ b/script/mux/idle.sh
@@ -28,7 +28,7 @@ DISPLAY_ACTIVE() {
 # from dimming the display or going to sleep.
 while true; do
 	case "$(GET_VAR system foreground_process)" in
-		fbpad | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
+		fbpad | ffplay | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
 		*) IDLE_INHIBIT=0 ;;
 	esac
 	# evsieve grabs input devices for exclusive access, preventing muhotkey


### PR DESCRIPTION
[Issue reported on Discord](https://discord.com/channels/1152022492001603615/1295783330352201728)

Also took this chance to move the shared idle functionality to reduce some duplication. (I did add a device type check for the RGB bit.... We have that same check elsewhere, but maybe we should just have a proper `rgb = 0/1` device var or some such.)