### PR TITLE
Work around Drastic-Steward hang right after boot

### DIFF
--- a/script/mux/frontend.sh
+++ b/script/mux/frontend.sh
@@ -108,7 +108,7 @@ if [ "$(GET_VAR "global" "settings/general/startup")" = "last" ] || [ "$(GET_VAR
 		if [ "$(cat "$(GET_VAR "device" "network/state")")" = "up" ] || [ "$(cat "$NET_START")" = "ignore" ] || [ "$(GET_VAR "global" "network/enabled")" -eq 0 ] || [ "$(GET_VAR "global" "settings/advanced/retrowait")" -eq 0 ]; then
 			LOGGER "$0" "FRONTEND" "Booting to last launched content"
 			cat "$LAST_PLAY" >"$ROM_GO"
-			/opt/muos/script/mux/launch.sh
+			/opt/muos/script/mux/launch.sh last
 		fi
 	fi
 	echo launcher >$ACT_GO
@@ -172,7 +172,7 @@ while true; do
 	# Content Loader
 	if [ -s "$ROM_GO" ]; then
 		KILL_BGM
-		/opt/muos/script/mux/launch.sh
+		/opt/muos/script/mux/launch.sh list
 	fi
 
 	# Application Loader

--- a/script/mux/launch.sh
+++ b/script/mux/launch.sh
@@ -29,6 +29,7 @@ fi
 
 cat "$ROM_GO" >"$ROM_LAST"
 
+SOURCE=$1
 NAME=$(sed -n '1p' "$ROM_GO")
 CORE=$(sed -n '2p' "$ROM_GO" | tr -d '\n')
 R_DIR=$(sed -n '5p' "$ROM_GO")$(sed -n '6p' "$ROM_GO")
@@ -93,6 +94,11 @@ elif [ "${CORE#ext-pico8}" != "$CORE" ]; then
 	/opt/muos/script/launch/ext-pico8.sh "$NAME" "$CORE" "$ROM"
 # DraStic External
 elif [ "$CORE" = ext-drastic ]; then
+	if [ "$SOURCE" = last ]; then
+		# HACK: Drastic-Steward hangs when restarting right after boot.
+		# Possibly a muOS bug, but no other emulator has this issue....
+		sleep 1
+	fi
 	/opt/muos/script/launch/ext-drastic.sh "$NAME" "$CORE" "$ROM"
 # DraStic External - Legacy
 elif [ "$CORE" = ext-drastic-legacy ]; then


### PR DESCRIPTION
I verified Drastic-Legacy doesn't need this hack, only Drastic-Steward (now just called "Drastic" in the core selector).

Of course this is a super gross fix, and 1 second is long enough to be annoying as well, but it's better than hanging. (Ideally we'll figure out the root cause someday, as the issue seems specific to the Steward mods since it doesn't happen for the vanilla Drastic binary.)