### PR TITLE
Suppress idle sleep while charging

### DIFF
--- a/script/mux/idle.sh
+++ b/script/mux/idle.sh
@@ -2,6 +2,10 @@
 
 . /opt/muos/script/var/func.sh
 
+INHIBIT_NONE=0
+INHIBIT_BOTH=1
+INHIBIT_SLEEP=2
+
 LED_CONTROL=/opt/muos/device/current/script/led_control.sh
 RGBCONF=/run/muos/storage/theme/active/rgb/rgbconf.sh
 
@@ -24,13 +28,17 @@ DISPLAY_ACTIVE() {
 	esac
 }
 
-# Monitor for specific programs that should inhibit idle timeout and prevent us
-# from dimming the display or going to sleep.
+# Monitor for specific programs that should inhibit idle timeout.
 while true; do
+	INHIBIT="$INHIBIT_NONE"
+	# Inhibit idle sleep while charging.
+	if [ "$(cat "$(GET_VAR device battery/charger)")" -eq 1 ]; then
+	    INHIBIT="$INHIBIT_SLEEP"
+	fi
+	# Inhibit idle display and sleep during long-running processes.
 	case "$(GET_VAR system foreground_process)" in
-		fbpad | mpv | ffplay | muxcharge | muxcredits | muxstart) IDLE_INHIBIT=1 ;;
-		*) IDLE_INHIBIT=0 ;;
+		fbpad | ffplay | mpv | muxcharge | muxcredits | muxstart) INHIBIT="$INHIBIT_BOTH" ;;
 	esac
-	SET_VAR system idle_inhibit "$IDLE_INHIBIT"
+	SET_VAR system idle_inhibit "$INHIBIT"
 	sleep 5
 done &


### PR DESCRIPTION
[As discussed on Discord.](https://discord.com/channels/1152022492001603615/1297237782502051872) Should make it a bit easier to transfer files with idle sleep enabled. (The system will still dim the display with the charger enabled.)

Requires companion frontend PR: https://github.com/MustardOS/frontend/pull/122. 