### PR TITLE
Pass hotkey.json to muhotkey to parse directly

### DIFF
--- a/device/rg28xx/control/hotkey.json
+++ b/device/rg28xx/control/hotkey.json
@@ -1,12 +1,12 @@
-[
-  {"name": "OSF", "action": "press", "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
-  {"name": "SLEEP", "action": "press", "inputs": ["POWER_LONG"]},
-  {"name": "SCREENSHOT", "action": "press", "inputs": ["POWER_SHORT", "MENU_LONG"]},
-  {"name": "DPAD_TOGGLE", "action": "press", "inputs": ["POWER_SHORT"]},
-  {"name": "BRIGHT_UP", "action": "hold", "inputs": ["VOL_UP", "MENU_LONG"]},
-  {"name": "VOL_UP", "action": "hold", "inputs": ["VOL_UP"]},
-  {"name": "BRIGHT_DOWN", "action": "hold", "inputs": ["VOL_DOWN", "MENU_LONG"]},
-  {"name": "VOL_DOWN", "action": "hold", "inputs": ["VOL_DOWN"]},
-  {"name": "RETROWAIT_IGNORE", "action": "press", "inputs": ["START"]},
-  {"name": "RETROWAIT_MENU", "action": "press", "inputs": ["SELECT"]}
-]
+{
+  "BRIGHT_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN", "MENU_LONG"]},
+  "BRIGHT_UP": {"handle_hold": true, "inputs": ["VOL_UP", "MENU_LONG"]},
+  "DPAD_TOGGLE": {"handle_hold": false, "inputs": ["POWER_SHORT"]},
+  "OSF": {"handle_hold": false, "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
+  "RETROWAIT_IGNORE": {"handle_hold": false, "inputs": ["START"]},
+  "RETROWAIT_MENU": {"handle_hold": false, "inputs": ["SELECT"]},
+  "SCREENSHOT": {"handle_hold": false, "inputs": ["POWER_SHORT", "MENU_LONG"]},
+  "SLEEP": {"handle_hold": false, "inputs": ["POWER_LONG"]},
+  "VOL_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN"]},
+  "VOL_UP": {"handle_hold": true, "inputs": ["VOL_UP"]}
+}

--- a/device/rg35xx-2024/control/hotkey.json
+++ b/device/rg35xx-2024/control/hotkey.json
@@ -1,12 +1,12 @@
-[
-  {"name": "OSF", "action": "press", "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
-  {"name": "SLEEP", "action": "press", "inputs": ["POWER_LONG"]},
-  {"name": "SCREENSHOT", "action": "press", "inputs": ["POWER_SHORT", "MENU_LONG"]},
-  {"name": "DPAD_TOGGLE", "action": "press", "inputs": ["POWER_SHORT"]},
-  {"name": "BRIGHT_UP", "action": "hold", "inputs": ["VOL_UP", "MENU_LONG"]},
-  {"name": "VOL_UP", "action": "hold", "inputs": ["VOL_UP"]},
-  {"name": "BRIGHT_DOWN", "action": "hold", "inputs": ["VOL_DOWN", "MENU_LONG"]},
-  {"name": "VOL_DOWN", "action": "hold", "inputs": ["VOL_DOWN"]},
-  {"name": "RETROWAIT_IGNORE", "action": "press", "inputs": ["START"]},
-  {"name": "RETROWAIT_MENU", "action": "press", "inputs": ["SELECT"]}
-]
+{
+  "BRIGHT_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN", "MENU_LONG"]},
+  "BRIGHT_UP": {"handle_hold": true, "inputs": ["VOL_UP", "MENU_LONG"]},
+  "DPAD_TOGGLE": {"handle_hold": false, "inputs": ["POWER_SHORT"]},
+  "OSF": {"handle_hold": false, "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
+  "RETROWAIT_IGNORE": {"handle_hold": false, "inputs": ["START"]},
+  "RETROWAIT_MENU": {"handle_hold": false, "inputs": ["SELECT"]},
+  "SCREENSHOT": {"handle_hold": false, "inputs": ["POWER_SHORT", "MENU_LONG"]},
+  "SLEEP": {"handle_hold": false, "inputs": ["POWER_LONG"]},
+  "VOL_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN"]},
+  "VOL_UP": {"handle_hold": true, "inputs": ["VOL_UP"]}
+}

--- a/device/rg35xx-h/control/hotkey.json
+++ b/device/rg35xx-h/control/hotkey.json
@@ -1,11 +1,11 @@
-[
-  {"name": "OSF", "action": "press", "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
-  {"name": "SLEEP", "action": "press", "inputs": ["POWER_LONG"]},
-  {"name": "SCREENSHOT", "action": "press", "inputs": ["POWER_SHORT", "MENU_LONG"]},
-  {"name": "BRIGHT_UP", "action": "hold", "inputs": ["VOL_UP", "MENU_LONG"]},
-  {"name": "VOL_UP", "action": "hold", "inputs": ["VOL_UP"]},
-  {"name": "BRIGHT_DOWN", "action": "hold", "inputs": ["VOL_DOWN", "MENU_LONG"]},
-  {"name": "VOL_DOWN", "action": "hold", "inputs": ["VOL_DOWN"]},
-  {"name": "RETROWAIT_IGNORE", "action": "press", "inputs": ["START"]},
-  {"name": "RETROWAIT_MENU", "action": "press", "inputs": ["SELECT"]}
-]
+{
+  "BRIGHT_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN", "MENU_LONG"]},
+  "BRIGHT_UP": {"handle_hold": true, "inputs": ["VOL_UP", "MENU_LONG"]},
+  "OSF": {"handle_hold": false, "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
+  "RETROWAIT_IGNORE": {"handle_hold": false, "inputs": ["START"]},
+  "RETROWAIT_MENU": {"handle_hold": false, "inputs": ["SELECT"]},
+  "SCREENSHOT": {"handle_hold": false, "inputs": ["POWER_SHORT", "MENU_LONG"]},
+  "SLEEP": {"handle_hold": false, "inputs": ["POWER_LONG"]},
+  "VOL_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN"]},
+  "VOL_UP": {"handle_hold": true, "inputs": ["VOL_UP"]}
+}

--- a/device/rg35xx-plus/control/hotkey.json
+++ b/device/rg35xx-plus/control/hotkey.json
@@ -1,12 +1,12 @@
-[
-  {"name": "OSF", "action": "press", "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
-  {"name": "SLEEP", "action": "press", "inputs": ["POWER_LONG"]},
-  {"name": "SCREENSHOT", "action": "press", "inputs": ["POWER_SHORT", "MENU_LONG"]},
-  {"name": "DPAD_TOGGLE", "action": "press", "inputs": ["POWER_SHORT"]},
-  {"name": "BRIGHT_UP", "action": "hold", "inputs": ["VOL_UP", "MENU_LONG"]},
-  {"name": "VOL_UP", "action": "hold", "inputs": ["VOL_UP"]},
-  {"name": "BRIGHT_DOWN", "action": "hold", "inputs": ["VOL_DOWN", "MENU_LONG"]},
-  {"name": "VOL_DOWN", "action": "hold", "inputs": ["VOL_DOWN"]},
-  {"name": "RETROWAIT_IGNORE", "action": "press", "inputs": ["START"]},
-  {"name": "RETROWAIT_MENU", "action": "press", "inputs": ["SELECT"]}
-]
+{
+  "BRIGHT_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN", "MENU_LONG"]},
+  "BRIGHT_UP": {"handle_hold": true, "inputs": ["VOL_UP", "MENU_LONG"]},
+  "DPAD_TOGGLE": {"handle_hold": false, "inputs": ["POWER_SHORT"]},
+  "OSF": {"handle_hold": false, "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
+  "RETROWAIT_IGNORE": {"handle_hold": false, "inputs": ["START"]},
+  "RETROWAIT_MENU": {"handle_hold": false, "inputs": ["SELECT"]},
+  "SCREENSHOT": {"handle_hold": false, "inputs": ["POWER_SHORT", "MENU_LONG"]},
+  "SLEEP": {"handle_hold": false, "inputs": ["POWER_LONG"]},
+  "VOL_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN"]},
+  "VOL_UP": {"handle_hold": true, "inputs": ["VOL_UP"]}
+}

--- a/device/rg35xx-sp/control/hotkey.json
+++ b/device/rg35xx-sp/control/hotkey.json
@@ -1,12 +1,12 @@
-[
-  {"name": "OSF", "action": "press", "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
-  {"name": "SLEEP", "action": "press", "inputs": ["POWER_LONG"]},
-  {"name": "SCREENSHOT", "action": "press", "inputs": ["POWER_SHORT", "MENU_LONG"]},
-  {"name": "DPAD_TOGGLE", "action": "press", "inputs": ["POWER_SHORT"]},
-  {"name": "BRIGHT_UP", "action": "hold", "inputs": ["VOL_UP", "MENU_LONG"]},
-  {"name": "VOL_UP", "action": "hold", "inputs": ["VOL_UP"]},
-  {"name": "BRIGHT_DOWN", "action": "hold", "inputs": ["VOL_DOWN", "MENU_LONG"]},
-  {"name": "VOL_DOWN", "action": "hold", "inputs": ["VOL_DOWN"]},
-  {"name": "RETROWAIT_IGNORE", "action": "press", "inputs": ["START"]},
-  {"name": "RETROWAIT_MENU", "action": "press", "inputs": ["SELECT"]}
-]
+{
+  "BRIGHT_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN", "MENU_LONG"]},
+  "BRIGHT_UP": {"handle_hold": true, "inputs": ["VOL_UP", "MENU_LONG"]},
+  "DPAD_TOGGLE": {"handle_hold": false, "inputs": ["POWER_SHORT"]},
+  "OSF": {"handle_hold": false, "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
+  "RETROWAIT_IGNORE": {"handle_hold": false, "inputs": ["START"]},
+  "RETROWAIT_MENU": {"handle_hold": false, "inputs": ["SELECT"]},
+  "SCREENSHOT": {"handle_hold": false, "inputs": ["POWER_SHORT", "MENU_LONG"]},
+  "SLEEP": {"handle_hold": false, "inputs": ["POWER_LONG"]},
+  "VOL_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN"]},
+  "VOL_UP": {"handle_hold": true, "inputs": ["VOL_UP"]}
+}

--- a/device/rg40xx-h/control/hotkey.json
+++ b/device/rg40xx-h/control/hotkey.json
@@ -1,16 +1,16 @@
-[
-  {"name": "OSF", "action": "press", "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
-  {"name": "SLEEP", "action": "press", "inputs": ["POWER_LONG"]},
-  {"name": "SCREENSHOT", "action": "press", "inputs": ["POWER_SHORT", "MENU_LONG"]},
-  {"name": "BRIGHT_UP", "action": "hold", "inputs": ["VOL_UP", "MENU_LONG"]},
-  {"name": "VOL_UP", "action": "hold", "inputs": ["VOL_UP"]},
-  {"name": "BRIGHT_DOWN", "action": "hold", "inputs": ["VOL_DOWN", "MENU_LONG"]},
-  {"name": "VOL_DOWN", "action": "hold", "inputs": ["VOL_DOWN"]},
-  {"name": "RGB_MODE", "action": "press", "inputs": ["R3", "MENU_LONG"]},
-  {"name": "RGB_BRIGHT_UP", "action": "press", "inputs": ["RS_UP", "MENU_LONG"]},
-  {"name": "RGB_BRIGHT_DOWN", "action": "press", "inputs": ["RS_DOWN", "MENU_LONG"]},
-  {"name": "RGB_COLOR_PREV", "action": "press", "inputs": ["RS_LEFT", "MENU_LONG"]},
-  {"name": "RGB_COLOR_NEXT", "action": "press", "inputs": ["RS_RIGHT", "MENU_LONG"]},
-  {"name": "RETROWAIT_IGNORE", "action": "press", "inputs": ["START"]},
-  {"name": "RETROWAIT_MENU", "action": "press", "inputs": ["SELECT"]}
-]
+{
+  "BRIGHT_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN", "MENU_LONG"]},
+  "BRIGHT_UP": {"handle_hold": true, "inputs": ["VOL_UP", "MENU_LONG"]},
+  "OSF": {"handle_hold": false, "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
+  "RETROWAIT_IGNORE": {"handle_hold": false, "inputs": ["START"]},
+  "RETROWAIT_MENU": {"handle_hold": false, "inputs": ["SELECT"]},
+  "RGB_BRIGHT_DOWN": {"handle_hold": false, "inputs": ["RS_DOWN", "MENU_LONG"]},
+  "RGB_BRIGHT_UP": {"handle_hold": false, "inputs": ["RS_UP", "MENU_LONG"]},
+  "RGB_COLOR_NEXT": {"handle_hold": false, "inputs": ["RS_RIGHT", "MENU_LONG"]},
+  "RGB_COLOR_PREV": {"handle_hold": false, "inputs": ["RS_LEFT", "MENU_LONG"]},
+  "RGB_MODE": {"handle_hold": false, "inputs": ["R3", "MENU_LONG"]},
+  "SCREENSHOT": {"handle_hold": false, "inputs": ["POWER_SHORT", "MENU_LONG"]},
+  "SLEEP": {"handle_hold": false, "inputs": ["POWER_LONG"]},
+  "VOL_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN"]},
+  "VOL_UP": {"handle_hold": true, "inputs": ["VOL_UP"]}
+}

--- a/device/rg40xx-v/control/hotkey.json
+++ b/device/rg40xx-v/control/hotkey.json
@@ -1,16 +1,16 @@
-[
-  {"name": "OSF", "action": "press", "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
-  {"name": "SLEEP", "action": "press", "inputs": ["POWER_LONG"]},
-  {"name": "SCREENSHOT", "action": "press", "inputs": ["POWER_SHORT", "MENU_LONG"]},
-  {"name": "BRIGHT_UP", "action": "hold", "inputs": ["VOL_UP", "MENU_LONG"]},
-  {"name": "VOL_UP", "action": "hold", "inputs": ["VOL_UP"]},
-  {"name": "BRIGHT_DOWN", "action": "hold", "inputs": ["VOL_DOWN", "MENU_LONG"]},
-  {"name": "VOL_DOWN", "action": "hold", "inputs": ["VOL_DOWN"]},
-  {"name": "RGB_MODE", "action": "press", "inputs": ["L3", "MENU_LONG"]},
-  {"name": "RGB_BRIGHT_UP", "action": "press", "inputs": ["LS_UP", "MENU_LONG"]},
-  {"name": "RGB_BRIGHT_DOWN", "action": "press", "inputs": ["LS_DOWN", "MENU_LONG"]},
-  {"name": "RGB_COLOR_PREV", "action": "press", "inputs": ["LS_LEFT", "MENU_LONG"]},
-  {"name": "RGB_COLOR_NEXT", "action": "press", "inputs": ["LS_RIGHT", "MENU_LONG"]},
-  {"name": "RETROWAIT_IGNORE", "action": "press", "inputs": ["START"]},
-  {"name": "RETROWAIT_MENU", "action": "press", "inputs": ["SELECT"]}
-]
+{
+  "BRIGHT_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN", "MENU_LONG"]},
+  "BRIGHT_UP": {"handle_hold": true, "inputs": ["VOL_UP", "MENU_LONG"]},
+  "OSF": {"handle_hold": false, "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
+  "RETROWAIT_IGNORE": {"handle_hold": false, "inputs": ["START"]},
+  "RETROWAIT_MENU": {"handle_hold": false, "inputs": ["SELECT"]},
+  "RGB_BRIGHT_DOWN": {"handle_hold": false, "inputs": ["LS_DOWN", "MENU_LONG"]},
+  "RGB_BRIGHT_UP": {"handle_hold": false, "inputs": ["LS_UP", "MENU_LONG"]},
+  "RGB_COLOR_NEXT": {"handle_hold": false, "inputs": ["LS_RIGHT", "MENU_LONG"]},
+  "RGB_COLOR_PREV": {"handle_hold": false, "inputs": ["LS_LEFT", "MENU_LONG"]},
+  "RGB_MODE": {"handle_hold": false, "inputs": ["L3", "MENU_LONG"]},
+  "SCREENSHOT": {"handle_hold": false, "inputs": ["POWER_SHORT", "MENU_LONG"]},
+  "SLEEP": {"handle_hold": false, "inputs": ["POWER_LONG"]},
+  "VOL_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN"]},
+  "VOL_UP": {"handle_hold": true, "inputs": ["VOL_UP"]}
+}

--- a/device/rgcubexx-h/control/hotkey.json
+++ b/device/rgcubexx-h/control/hotkey.json
@@ -1,16 +1,16 @@
-[
-  {"name": "OSF", "action": "press", "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
-  {"name": "SLEEP", "action": "press", "inputs": ["POWER_LONG"]},
-  {"name": "SCREENSHOT", "action": "press", "inputs": ["POWER_SHORT", "MENU_LONG"]},
-  {"name": "BRIGHT_UP", "action": "hold", "inputs": ["VOL_UP", "MENU_LONG"]},
-  {"name": "VOL_UP", "action": "hold", "inputs": ["VOL_UP"]},
-  {"name": "BRIGHT_DOWN", "action": "hold", "inputs": ["VOL_DOWN", "MENU_LONG"]},
-  {"name": "VOL_DOWN", "action": "hold", "inputs": ["VOL_DOWN"]},
-  {"name": "RGB_MODE", "action": "press", "inputs": ["R3", "MENU_LONG"]},
-  {"name": "RGB_BRIGHT_UP", "action": "press", "inputs": ["RS_UP", "MENU_LONG"]},
-  {"name": "RGB_BRIGHT_DOWN", "action": "press", "inputs": ["RS_DOWN", "MENU_LONG"]},
-  {"name": "RGB_COLOR_PREV", "action": "press", "inputs": ["RS_LEFT", "MENU_LONG"]},
-  {"name": "RGB_COLOR_NEXT", "action": "press", "inputs": ["RS_RIGHT", "MENU_LONG"]},
-  {"name": "RETROWAIT_IGNORE", "action": "press", "inputs": ["START"]},
-  {"name": "RETROWAIT_MENU", "action": "press", "inputs": ["SELECT"]}
-]
+{
+  "BRIGHT_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN", "MENU_LONG"]},
+  "BRIGHT_UP": {"handle_hold": true, "inputs": ["VOL_UP", "MENU_LONG"]},
+  "OSF": {"handle_hold": false, "inputs": ["POWER_LONG", "L1", "L2", "R1", "R2"]},
+  "RETROWAIT_IGNORE": {"handle_hold": false, "inputs": ["START"]},
+  "RETROWAIT_MENU": {"handle_hold": false, "inputs": ["SELECT"]},
+  "RGB_BRIGHT_DOWN": {"handle_hold": false, "inputs": ["RS_DOWN", "MENU_LONG"]},
+  "RGB_BRIGHT_UP": {"handle_hold": false, "inputs": ["RS_UP", "MENU_LONG"]},
+  "RGB_COLOR_NEXT": {"handle_hold": false, "inputs": ["RS_RIGHT", "MENU_LONG"]},
+  "RGB_COLOR_PREV": {"handle_hold": false, "inputs": ["RS_LEFT", "MENU_LONG"]},
+  "RGB_MODE": {"handle_hold": false, "inputs": ["R3", "MENU_LONG"]},
+  "SCREENSHOT": {"handle_hold": false, "inputs": ["POWER_SHORT", "MENU_LONG"]},
+  "SLEEP": {"handle_hold": false, "inputs": ["POWER_LONG"]},
+  "VOL_DOWN": {"handle_hold": true, "inputs": ["VOL_DOWN"]},
+  "VOL_UP": {"handle_hold": true, "inputs": ["VOL_UP"]}
+}

--- a/script/mux/hotkey.sh
+++ b/script/mux/hotkey.sh
@@ -5,7 +5,6 @@
 . /opt/muos/script/mux/close_game.sh
 . /opt/muos/script/mux/idle.sh
 
-HOTKEY_JSON_FILE=/opt/muos/config/hotkey.json
 SLEEP_STATE_FILE=/tmp/sleep_state
 POWER_LONG_FILE=/tmp/trigger/POWER_LONG
 
@@ -17,14 +16,7 @@ RGBCONTROLLER_DIR="$(GET_VAR device storage/rom/mount)/MUOS/application/.rgbcont
 READ_HOTKEYS() {
 	# Restart muhotkey if it exits. (tweak.sh kills it on config changes.)
 	while true; do
-		# Restore default hotkey.json if missing.
-		if [ ! -f "$HOTKEY_JSON_FILE" ]; then
-			cp /opt/muos/device/current/control/hotkey.json "$HOTKEY_JSON_FILE"
-		fi
-
-		# TODO: Parse JSON in muhotkey instead of converting it here.
-		jq -r '.[] | [{press: "-C", hold: "-H"}[.action], "\(.name)=\(.inputs | join("+"))"] | .[]' "$HOTKEY_JSON_FILE" \
-			| xargs /opt/muos/extra/muhotkey
+		/opt/muos/extra/muhotkey /opt/muos/device/current/control/hotkey.json
 	done
 }
 


### PR DESCRIPTION
Depends on https://github.com/MustardOS/frontend/pull/128.

I tweaked the JSON format to group the hotkeys in an object rather than an array, since the accompanying change to `muhotkey` causes it to sort the hotkeys correctly (from longest to shortest) automatically.

I also removed the copying of hotkey.json from `/opt/muos/device/current/control` to `/opt/muos/config`, since this will make incremental updates that add hotkeys a bit simpler. (We can revisit this in the future if we ever do want to add a GUI for hotkey editing.)