### PR TITLE
Bump version.txt to match upcoming patch

### DIFF
--- a/config/version.txt
+++ b/config/version.txt
@@ -1,2 +1,2 @@
-2410.1 BANANA
-aa34f0b8
+2410.2 BANANA
+xxxxxxxx


### PR DESCRIPTION
Also sets build label in `version.txt` to a dummy value (`xxxxxxxx`). Both the full release and incremental update flows should replace it with the Git commit, so this gives an obvious indicator if that doesn't happen.