### PR TITLE
Fix Save/Load mupen64 external Hotkeys for RG35XX-Plus and RG35XX-2024

### DIFF
--- a/device/rg35xx-2024/control/mupen64plus-gl64.cfg
+++ b/device/rg35xx-2024/control/mupen64plus-gl64.cfg
@@ -140,9 +140,9 @@ Joy Mapping Stop = "J0B11/B10"
 # Joystick event string for switching between fullscreen/windowed modes
 Joy Mapping Fullscreen = ""
 # Joystick event string for saving the emulator state
-Joy Mapping Save State = "J0B11/B14"
+Joy Mapping Save State = "J0B11/B13"
 # Joystick event string for loading the emulator state
-Joy Mapping Load State = "J0B11/B13"
+Joy Mapping Load State = "J0B11/B12"
 # Joystick event string for advancing the save state slot
 Joy Mapping Increment Slot = "J0B11/H0V2"
 # Joystick event string for resetting the emulator

--- a/device/rg35xx-2024/control/mupen64plus-rice.cfg
+++ b/device/rg35xx-2024/control/mupen64plus-rice.cfg
@@ -140,9 +140,9 @@ Joy Mapping Stop = "J0B11/B10"
 # Joystick event string for switching between fullscreen/windowed modes
 Joy Mapping Fullscreen = ""
 # Joystick event string for saving the emulator state
-Joy Mapping Save State = "J0B11/B14"
+Joy Mapping Save State = "J0B11/B13"
 # Joystick event string for loading the emulator state
-Joy Mapping Load State = "J0B11/B13"
+Joy Mapping Load State = "J0B11/B12"
 # Joystick event string for advancing the save state slot
 Joy Mapping Increment Slot = "J0B11/H0V2"
 # Joystick event string for resetting the emulator

--- a/device/rg35xx-plus/control/mupen64plus-gl64.cfg
+++ b/device/rg35xx-plus/control/mupen64plus-gl64.cfg
@@ -140,9 +140,9 @@ Joy Mapping Stop = "J0B11/B10"
 # Joystick event string for switching between fullscreen/windowed modes
 Joy Mapping Fullscreen = ""
 # Joystick event string for saving the emulator state
-Joy Mapping Save State = "J0B11/B14"
+Joy Mapping Save State = "J0B11/B13"
 # Joystick event string for loading the emulator state
-Joy Mapping Load State = "J0B11/B13"
+Joy Mapping Load State = "J0B11/B12"
 # Joystick event string for advancing the save state slot
 Joy Mapping Increment Slot = "J0B11/H0V2"
 # Joystick event string for resetting the emulator

--- a/device/rg35xx-plus/control/mupen64plus-rice.cfg
+++ b/device/rg35xx-plus/control/mupen64plus-rice.cfg
@@ -140,9 +140,9 @@ Joy Mapping Stop = "J0B11/B10"
 # Joystick event string for switching between fullscreen/windowed modes
 Joy Mapping Fullscreen = ""
 # Joystick event string for saving the emulator state
-Joy Mapping Save State = "J0B11/B14"
+Joy Mapping Save State = "J0B11/B13"
 # Joystick event string for loading the emulator state
-Joy Mapping Load State = "J0B11/B13"
+Joy Mapping Load State = "J0B11/B12"
 # Joystick event string for advancing the save state slot
 Joy Mapping Increment Slot = "J0B11/H0V2"
 # Joystick event string for resetting the emulator


### PR DESCRIPTION
This is similar to this [PR](https://github.com/MustardOS/internal/pull/325) from antiKk but aiming at fixing for mupen64 external (rice / gl64)