### PR TITLE
Minor tweaks to extract and halt scripts

### DIFF
--- a/device/rg28xx/input/trigger/sleep.sh
+++ b/device/rg28xx/input/trigger/sleep.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 . /opt/muos/script/var/func.sh
-. /opt/muos/script/mux/close_game.sh
 
 SLEEP_STATE="/tmp/sleep_state"
 SLEEP_TIMER="/tmp/sleep_timer"
@@ -22,7 +21,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$(GET_VAR "global" "settings/power/shutdown")" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		HALT_SYSTEM sleep poweroff
+		/opt/muos/script/mux/quit.sh poweroff sleep
 	fi
 
 	sleep 1

--- a/device/rg35xx-2024/input/trigger/sleep.sh
+++ b/device/rg35xx-2024/input/trigger/sleep.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 . /opt/muos/script/var/func.sh
-. /opt/muos/script/mux/close_game.sh
 
 SLEEP_STATE="/tmp/sleep_state"
 SLEEP_TIMER="/tmp/sleep_timer"
@@ -22,7 +21,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$(GET_VAR "global" "settings/power/shutdown")" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		HALT_SYSTEM sleep poweroff
+		/opt/muos/script/mux/quit.sh poweroff sleep
 	fi
 
 	sleep 1

--- a/device/rg35xx-h/input/trigger/sleep.sh
+++ b/device/rg35xx-h/input/trigger/sleep.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 . /opt/muos/script/var/func.sh
-. /opt/muos/script/mux/close_game.sh
 
 SLEEP_STATE="/tmp/sleep_state"
 SLEEP_TIMER="/tmp/sleep_timer"
@@ -22,7 +21,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$(GET_VAR "global" "settings/power/shutdown")" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		HALT_SYSTEM sleep poweroff
+		/opt/muos/script/mux/quit.sh poweroff sleep
 	fi
 
 	sleep 1

--- a/device/rg35xx-plus/input/trigger/sleep.sh
+++ b/device/rg35xx-plus/input/trigger/sleep.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 . /opt/muos/script/var/func.sh
-. /opt/muos/script/mux/close_game.sh
 
 SLEEP_STATE="/tmp/sleep_state"
 SLEEP_TIMER="/tmp/sleep_timer"
@@ -22,7 +21,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$(GET_VAR "global" "settings/power/shutdown")" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		HALT_SYSTEM sleep poweroff
+		/opt/muos/script/mux/quit.sh poweroff sleep
 	fi
 
 	sleep 1

--- a/device/rg35xx-sp/input/trigger/power.sh
+++ b/device/rg35xx-sp/input/trigger/power.sh
@@ -2,8 +2,6 @@
 
 . /opt/muos/script/var/func.sh
 
-. /opt/muos/script/mux/close_game.sh
-
 TMP_POWER_LONG="/tmp/trigger/POWER_LONG"
 
 HALL_KEY="/sys/class/power_supply/axp2202-battery/hallkey"
@@ -91,7 +89,7 @@ while true; do
 			# Sleep Suspend:
 			-1) /opt/muos/script/system/suspend.sh power ;;
 			# Instant Shutdown:
-			2) HALT_SYSTEM sleep poweroff ;;
+			2) /opt/muos/script/mux/quit.sh poweroff sleep ;;
 			# Sleep XXs + Shutdown:
 			*)
 				if pgrep -f "playbgm.sh" >/dev/null; then

--- a/device/rg35xx-sp/input/trigger/sleep.sh
+++ b/device/rg35xx-sp/input/trigger/sleep.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 . /opt/muos/script/var/func.sh
-. /opt/muos/script/mux/close_game.sh
 
 SLEEP_STATE="/tmp/sleep_state"
 SLEEP_TIMER="/tmp/sleep_timer"
@@ -22,7 +21,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$(GET_VAR "global" "settings/power/shutdown")" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		HALT_SYSTEM sleep poweroff
+		/opt/muos/script/mux/quit.sh poweroff sleep
 	fi
 
 	sleep 1

--- a/device/rg40xx-h/input/trigger/sleep.sh
+++ b/device/rg40xx-h/input/trigger/sleep.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 . /opt/muos/script/var/func.sh
-. /opt/muos/script/mux/close_game.sh
 
 SLEEP_STATE="/tmp/sleep_state"
 SLEEP_TIMER="/tmp/sleep_timer"
@@ -22,7 +21,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$(GET_VAR "global" "settings/power/shutdown")" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		HALT_SYSTEM sleep poweroff
+		/opt/muos/script/mux/quit.sh poweroff sleep
 	fi
 
 	sleep 1

--- a/device/rg40xx-v/input/trigger/sleep.sh
+++ b/device/rg40xx-v/input/trigger/sleep.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 . /opt/muos/script/var/func.sh
-. /opt/muos/script/mux/close_game.sh
 
 SLEEP_STATE="/tmp/sleep_state"
 SLEEP_TIMER="/tmp/sleep_timer"
@@ -22,7 +21,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$(GET_VAR "global" "settings/power/shutdown")" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		HALT_SYSTEM sleep poweroff
+		/opt/muos/script/mux/quit.sh poweroff sleep
 	fi
 
 	sleep 1

--- a/device/rgcubexx-h/input/trigger/sleep.sh
+++ b/device/rgcubexx-h/input/trigger/sleep.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 . /opt/muos/script/var/func.sh
-. /opt/muos/script/mux/close_game.sh
 
 SLEEP_STATE="/tmp/sleep_state"
 SLEEP_TIMER="/tmp/sleep_timer"
@@ -22,7 +21,7 @@ while true; do
 
 	if [ "$SLEEP_TIMER_VAL" -eq "$(GET_VAR "global" "settings/power/shutdown")" ]; then
 		/opt/muos/script/system/suspend.sh resume
-		HALT_SYSTEM sleep poweroff
+		/opt/muos/script/mux/quit.sh poweroff sleep
 	fi
 
 	sleep 1

--- a/script/mux/extract.sh
+++ b/script/mux/extract.sh
@@ -31,7 +31,11 @@ if unzip -l "$1" | awk '$NF ~ /^'"$SCHEME_FOLDER"'\// && $NF ~ /\/'"$SCHEME_FILE
 	echo "Copying unextracted archive to theme folder"
 	cp -f "$1" "/run/muos/storage/theme/"
 else
+	# Count total files in archive to show progress bar for unzip and rsync.
+	# Not as precise as monitoring bytes decompressed, but much easier, and
+	# still gives a high-level indication how far along the process is.
 	FILE_COUNT="$(unzip -Z1 "$1" | grep -cv '/$')"
+
 	MUX_TEMP="/opt/muxtmp"
 	mkdir "$MUX_TEMP"
 

--- a/script/mux/frontend.sh
+++ b/script/mux/frontend.sh
@@ -6,7 +6,6 @@ case ":$LD_LIBRARY_PATH:" in
 esac
 
 . /opt/muos/script/var/func.sh
-. /opt/muos/script/mux/close_game.sh
 
 DEV_BOARD=$(GET_VAR "device" "board/name")
 case "$DEV_BOARD" in
@@ -434,10 +433,10 @@ while true; do
 				nice --20 /opt/muos/extra/muxcredits
 				;;
 			"reboot")
-				HALT_SYSTEM frontend reboot
+				/opt/muos/script/mux/quit.sh reboot frontend
 				;;
 			"shutdown")
-				HALT_SYSTEM frontend poweroff
+				/opt/muos/script/mux/quit.sh poweroff frontend
 				;;
 		esac
 	fi

--- a/script/mux/hotkey.sh
+++ b/script/mux/hotkey.sh
@@ -2,7 +2,6 @@
 
 . /opt/muos/script/var/func.sh
 
-. /opt/muos/script/mux/close_game.sh
 . /opt/muos/script/mux/idle.sh
 
 SLEEP_STATE_FILE=/tmp/sleep_state
@@ -29,7 +28,7 @@ HANDLE_HOTKEY() {
 		IDLE_SLEEP) SLEEP ;;
 
 		# Power combos:
-		OSF) HALT_SYSTEM osf reboot ;;
+		OSF) /opt/muos/script/mux/quit.sh reboot osf ;;
 		SLEEP) SLEEP ;;
 
 		# Utility combos:
@@ -77,7 +76,7 @@ SLEEP() {
 			fi
 			;;
 		# Instant Shutdown:
-		2) HALT_SYSTEM sleep poweroff ;;
+		2) /opt/muos/script/mux/quit.sh poweroff sleep ;;
 		# Sleep XXs + Shutdown:
 		*)
 			if [ ! -e "$POWER_LONG_FILE" ] || [ "$(cat "$POWER_LONG_FILE")" = off ]; then

--- a/script/system/startup.sh
+++ b/script/system/startup.sh
@@ -99,9 +99,7 @@ if [ "$(GET_VAR "global" "boot/factory_reset")" -eq 1 ]; then
 	rm -f "/opt/muos/factory.mp3"
 
 	/opt/muos/extra/muxcredits
-
-	. /opt/muos/script/mux/close_game.sh
-	HALT_SYSTEM frontend reboot
+	/opt/muos/script/mux/quit.sh reboot frontend
 fi
 
 LOGGER "$0" "BOOTING" "Starting Low Power Indicator"


### PR DESCRIPTION
1. Toss in a comment on why the extraction progress bars count files and not bytes.
2. Change `/opt/muos/script/mux/close_game.sh` (a script that's sourced with functions to call) to `/opt/muos/script/mux/quit.sh`  (a script that's run as a separate program). Just a small cleanup I've been meaning to do for a while. (Requires corresponding update tool change: https://github.com/MustardOS/tool/pull/10.)
3. Fixes a bug where fbpad sometimes terminates early during shutdown with verbose messages on.