### PR TITLE
add support for empty wifi passwords

### DIFF
--- a/script/web/password.sh
+++ b/script/web/password.sh
@@ -7,10 +7,16 @@ PASS="$(GET_VAR "global" "network/pass")"
 
 WPA_CONFIG=/etc/wpa_supplicant.conf
 
-if [ ${#PASS} -eq 64 ]; then
+case ${#PASS} in
+    64)
 	printf "network={\n\tssid=\"%s\"\n\tpsk=%s\n}" "$SSID" "$PASS" >"$WPA_CONFIG"
-else
+        ;;
+    0)
+	printf "network={\n\tssid=\"%s\"\n\tkey_mgmt=NONE\n}" "$SSID" >"$WPA_CONFIG"
+        ;;
+    *)
 	wpa_passphrase "$SSID" "$PASS" | sed -n '/^[ \t]*psk=/s/^[ \t]*psk=//p' >"/run/muos/global/network/pass"
 	wpa_passphrase "$SSID" "$PASS" >"$WPA_CONFIG"
 	sed -i '3d' "$WPA_CONFIG"
-fi
+        ;;
+esac


### PR DESCRIPTION
wpa_supplicant uses "key_mgmt=NONE" for ssid's without a password
