### PR TITLE
Set Snes9x as default SNES/SFC core

### DIFF
--- a/init/MUOS/info/assign/Nintendo SNES-SFC.ini
+++ b/init/MUOS/info/assign/Nintendo SNES-SFC.ini
@@ -1,27 +1,47 @@
 [global]
 name=Nintendo SNES-SFC
-default=ChimeraSNES
+default=Snes9x
 catalogue=Nintendo SNES-SFC
 cache=0
 governor=ondemand
 
+[bios]
+file_0=BS-X.bin
+hash_0=fed4d8242cfbed61343d53d48432aced
+file_1=STBIOS.bin
+hash_1=d3a44ba7d42a74d3ac58cb9c14c6a5ca
+
 [Beetle Supafaust]
 core=mednafen_supafaust_libretro.so
+bios_required=0
+external=0
 
 [ChimeraSNES]
 core=chimerasnes_libretro.so
+bios_required=0
+external=0
 
 [Snes9x]
 core=snes9x_libretro.so
+bios_required=0
+external=0
 
 [Snes9x 2002]
 core=snes9x2002_libretro.so
+bios_required=0
+external=0
 
 [Snes9x 2005]
 core=snes9x2005_libretro.so
+bios_required=0
+external=0
 
 [Snes9x 2005 Plus]
 core=snes9x2005_plus_libretro.so
+bios_required=0
+external=0
 
 [Snes9x 2010]
 core=snes9x2010_libretro.so
+bios_required=0
+external=0


### PR DESCRIPTION
Despite Supafaust being the superior core, it lacks Retro Achievement support.
Opting for ChimeraSNES sounded like a good plan, but the audio quality just isn't on par.

So here we are...

Additionally I took the opportunity to flesh out the ini with BIOS info.