### PR TITLE
Update Cube left stick codes for unpatched kernel

### DIFF
--- a/device/rgcubexx-h/config.ini
+++ b/device/rgcubexx-h/config.ini
@@ -136,10 +136,10 @@ left = 3
 right = 3
 
 [input.code.analog.left]
-up = 2
-down = 2
-left = 1
-right = 1
+up = 3
+down = 3
+left = 2
+right = 2
 click = 313
 
 [input.type.analog.left]


### PR DESCRIPTION
We are currently using a stock kernel without a stick driver patch, so we need the stock axis codes. Mappings from @duncanyoyo1's testing.

* LS up/down: ABS_RX (3)
* LS left/right: ABS_Z (2)

* RS up/down: ABS_RZ (5)
* RS left/right: ABS_RY (4)

(It's only the left stick that's swapped, for some reason.)