### PR TITLE
Change some default console aspect ratios to 4:3

### DIFF
--- a/init/MUOS/info/config/Atari800/Atari800.cfg
+++ b/init/MUOS/info/config/Atari800/Atari800.cfg
@@ -1,1 +1,1 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"

--- a/init/MUOS/info/config/DuckStation/DuckStation.cfg
+++ b/init/MUOS/info/config/DuckStation/DuckStation.cfg
@@ -1,1 +1,1 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"

--- a/init/MUOS/info/config/Flycast Xtreme/Flycast Xtreme.cfg
+++ b/init/MUOS/info/config/Flycast Xtreme/Flycast Xtreme.cfg
@@ -1,4 +1,4 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"
 audio_max_timing_skew = "0.050000"
 menu_wallpaper_opacity = "0.300000"
 slowmotion_ratio = "4.999998"

--- a/init/MUOS/info/config/Flycast/Flycast.cfg
+++ b/init/MUOS/info/config/Flycast/Flycast.cfg
@@ -1,4 +1,4 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"
 audio_max_timing_skew = "0.050000"
 menu_wallpaper_opacity = "0.300000"
 slowmotion_ratio = "4.999998"

--- a/init/MUOS/info/config/MorpheusCast Xtreme Acc/MorpheusCast Xtreme Acc.cfg
+++ b/init/MUOS/info/config/MorpheusCast Xtreme Acc/MorpheusCast Xtreme Acc.cfg
@@ -1,1 +1,1 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"

--- a/init/MUOS/info/config/Mupen64Plus-Next/Mupen64Plus-Next.cfg
+++ b/init/MUOS/info/config/Mupen64Plus-Next/Mupen64Plus-Next.cfg
@@ -1,1 +1,1 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"

--- a/init/MUOS/info/config/PCSX-ReARMed/PCSX-ReARMed.cfg
+++ b/init/MUOS/info/config/PCSX-ReARMed/PCSX-ReARMed.cfg
@@ -1,1 +1,1 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"

--- a/init/MUOS/info/config/ParaLLEl N64/ParaLLEl N64.cfg
+++ b/init/MUOS/info/config/ParaLLEl N64/ParaLLEl N64.cfg
@@ -1,1 +1,1 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"

--- a/init/MUOS/info/config/ProSystem/ProSystem.cfg
+++ b/init/MUOS/info/config/ProSystem/ProSystem.cfg
@@ -1,1 +1,1 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"

--- a/init/MUOS/info/config/SAME_CDI/SAME_CDI.cfg
+++ b/init/MUOS/info/config/SAME_CDI/SAME_CDI.cfg
@@ -1,1 +1,1 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"

--- a/init/MUOS/info/config/SMS Plus GX/SMS Plus GX.cfg
+++ b/init/MUOS/info/config/SMS Plus GX/SMS Plus GX.cfg
@@ -1,1 +1,1 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"

--- a/init/MUOS/info/config/SwanStation/SwanStation.cfg
+++ b/init/MUOS/info/config/SwanStation/SwanStation.cfg
@@ -1,1 +1,1 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"

--- a/init/MUOS/info/config/Virtual Jaguar/Virtual Jaguar.cfg
+++ b/init/MUOS/info/config/Virtual Jaguar/Virtual Jaguar.cfg
@@ -1,1 +1,1 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"

--- a/init/MUOS/info/config/YabaSanshiro/YabaSanshiro.cfg
+++ b/init/MUOS/info/config/YabaSanshiro/YabaSanshiro.cfg
@@ -1,1 +1,1 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"

--- a/init/MUOS/info/config/Yabause/Yabause.cfg
+++ b/init/MUOS/info/config/Yabause/Yabause.cfg
@@ -1,1 +1,1 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"

--- a/init/MUOS/info/config/a5200/a5200.cfg
+++ b/init/MUOS/info/config/a5200/a5200.cfg
@@ -1,1 +1,1 @@
-aspect_ratio_index = "22"
+aspect_ratio_index = "0"


### PR DESCRIPTION
@antiKk mind double checking this when you have a minute? AFAIK, all these systems targeted "normal" 4:3 TVs, so defaulting to 4:3 (0) for them may be a better default than Core Provided (22).

Systems affected:

* A5200
* A7800
* CDi
* Jaguar
* Dreamcast
* N64
* Saturn
* SMS
* PSX