### PR TITLE
Increase close-content timeout from 5s to 10s

### DIFF
--- a/script/mux/quit.sh
+++ b/script/mux/quit.sh
@@ -8,7 +8,7 @@ USAGE() {
 }
 
 # Attempts to cleanly close the current foreground process, resuming it first
-# if it's stopped. Waits five seconds before giving up.
+# if it's stopped. Waits ten seconds before giving up.
 CLOSE_CONTENT() {
 	FG_PROC_VAL=$(GET_VAR "system" "foreground_process")
 	FG_PROC_PID="$(pidof "$FG_PROC_VAL")"
@@ -22,7 +22,7 @@ CLOSE_CONTENT() {
 		sleep .01
 		kill "$FG_PROC_PID" 2>/dev/null
 
-		for _ in $(seq 1 20); do
+		for _ in $(seq 1 40); do
 			if ! kill -0 "$FG_PROC_PID" 2>/dev/null; then
 				printf 'done\n'
 				return


### PR DESCRIPTION
Since we've switched to a libretro core for N64, I've noticed the Mupen core can take 3-4 seconds to write the autosave, which is uncomfortably close to the 5 second timeout (especially since I'm using a pretty fast SD card, so it could be slower for others).

Doubling the timeout from 5s to 10s seems reasonable to me, especially since this only affects "instant shutdown" and "sleep XXs + shutdown" behavior where the screen is already blanked, etc. (We did a similar thing in the halt script for its own SIGTERM timeout already: #243.)