### PR TITLE
Script to save active theme as installable theme

### DIFF
--- a/init/MUOS/task/Save Active Theme.sh
+++ b/init/MUOS/task/Save Active Theme.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# HELP: Backup the active theme to a zip file with a timestamped name.
+# ICON: backup
+
+# Define the source directory to back up
+SOURCE_DIR="/run/muos/storage/theme/active"
+
+# Define the destination directory for the backup
+DEST_DIR="/run/muos/storage/theme"
+
+# Generate the timestamp for the backup filename
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+
+# Construct the destination file name
+DEST_FILE="$DEST_DIR/active-$TIMESTAMP.zip"
+
+# Check if the source directory exists
+if [ ! -d "$SOURCE_DIR" ]; then
+    echo "Source directory does not exist: $SOURCE_DIR"
+    exit 1
+fi
+
+# Navigate to the source directory and zip its contents at the root level
+echo "Backing up contents of $SOURCE_DIR to $DEST_FILE"
+cd "$SOURCE_DIR" || exit 1
+zip -r "$DEST_FILE" ./*
+
+echo "Backup complete: $DEST_FILE"
+
+# Synchronize filesystem to ensure all changes are saved
+echo "Sync Filesystem"
+sync
+
+echo "All Done!"
+sleep 2
+
+exit 0

--- a/init/MUOS/task/Save Active Theme.sh
+++ b/init/MUOS/task/Save Active Theme.sh
@@ -11,8 +11,20 @@ DEST_DIR="/run/muos/storage/theme"
 # Generate the timestamp for the backup filename
 TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 
+# Check if theme_name.txt exists and read the base theme name
+if [ -f "$SOURCE_DIR/theme_name.txt" ]; then
+    THEME_NAME_FILE="theme_name.txt"
+    BASE_THEME_NAME=$(sed -n '1p' "$SOURCE_DIR/$THEME_NAME_FILE")
+    echo "$BASE_THEME_NAME is the base theme name"
+else
+    BASE_THEME_NAME="active"
+    echo "theme_name.txt not found. Using default theme name: $BASE_THEME_NAME"
+fi
+
+echo "$BASE_THEME_NAME is the base theme name"
+
 # Construct the destination file name
-DEST_FILE="$DEST_DIR/active-$TIMESTAMP.zip"
+DEST_FILE="$DEST_DIR/$BASE_THEME_NAME-$TIMESTAMP.zip"
 
 # Check if the source directory exists
 if [ ! -d "$SOURCE_DIR" ]; then


### PR DESCRIPTION
This script will save the active theme folder as a separate theme, installable in the them picker, It will save the theme as active-<timestamp>.zip.

This is useful for when editing a theme in the active folder over ssh and wanting to package it up on device.