### PR TITLE
Bind all Pico-8 data to save folder

### DIFF
--- a/script/var/init/storage.sh
+++ b/script/var/init/storage.sh
@@ -50,9 +50,7 @@ BIND_EMULATOR save/file/OpenBOR-Ext openbor/userdata/saves/openbor
 BIND_EMULATOR screenshot openbor/userdata/screenshots/openbor
 
 # PICO-8
-for DIR in bbs cdata cstore desktop; do
-	BIND_EMULATOR "save/pico8/$DIR" "pico8/.lexaloffle/pico-8/$DIR"
-done
+BIND_EMULATOR "save/pico8" "pico8/.lexaloffle/pico-8"
 
 # PPSSPP
 BIND_EMULATOR save/file/PPSSPP-Ext ppsspp/.config/ppsspp/PSP/SAVEDATA


### PR DESCRIPTION
This binds all Pico-8 data to the save folder (instead of just the bbs, cdata, cstore, and desktop folders) so that the activity log, favorites and everything else don't get lost when wiping the OS