### PR TITLE
corrected YabaSanshiro corenames in Sega Saturn.ini and launch.sh

### DIFF
--- a/init/MUOS/info/assign/Sega Saturn.ini
+++ b/init/MUOS/info/assign/Sega Saturn.ini
@@ -1,18 +1,18 @@
 [global]
 name=Sega Saturn
-default=Yabasanshiro (External)
+default=YabaSanshiro (External)
 catalogue=Sega Saturn
 cache=0
 governor=performance
 
-[Yabasanshiro (External - No BIOS)]
-core=ext-yabasanshiro-hle
-
-[Yabasanshiro (External)]
-core=ext-yabasanshiro-bios
-
 [YabaSanshiro]
 core=yabasanshiro_libretro.so
+
+[YabaSanshiro (External - No BIOS)]
+core=ext-yabasanshiro-hle
+
+[YabaSanshiro (External)]
+core=ext-yabasanshiro-bios
 
 [Yabause]
 core=yabause_libretro.so

--- a/script/mux/launch.sh
+++ b/script/mux/launch.sh
@@ -107,7 +107,7 @@ elif [ "${CORE#ext-mupen64plus}" != "$CORE" ]; then
 # ScummVM External
 elif [ "$CORE" = ext-scummvm ]; then
 	/opt/muos/script/launch/ext-scummvm.sh "$NAME" "$CORE" "$ROM"
-# Yabasanshiro External
+# YabaSanshiro External
 elif [ "${CORE#ext-yabasanshiro}" != "$CORE" ]; then
 	/opt/muos/script/launch/ext-yabasanshiro.sh "$NAME" "$CORE" "$ROM"
 # Flycast Extreme LibRetro


### PR DESCRIPTION
Corrected a small descripancy in the case sensitivity, to allign spelling with the existing Yaba libretro core. 
Sorted Sega Saturn.ini like it appears on device