### PR TITLE
Assign Onscripter cores to RA. 

### DIFF
--- a/default/MUOS/info/assign/Onscripter.ini
+++ b/default/MUOS/info/assign/Onscripter.ini
@@ -1,0 +1,12 @@
+[global]
+name=Onscripter
+default=ONS
+catalogue=Onscripter
+cache=0
+governor=ondemand
+
+[ONS]
+core=onscripter_libretro.so
+
+[Onscripter-Yuri]
+core=onsyuri_libretro.so


### PR DESCRIPTION
These 2 cores are from Trimui Smart Pro STOCK in a Chinese community and they all work to open Chinese Onscripter games. Using onsyuri_libretro.so will show mouse curser on screen to have to choose save slot in some of the Onscripter GAME such as Fate Stay Night.
Put Onscripter.ini under MUOS\ONS\MUOS\info\assign
Put 2 cores under MUOS\core