### PR TITLE
Update Microsoft - MSX.ini

### DIFF
--- a/init/MUOS/info/assign/Microsoft - MSX.ini
+++ b/init/MUOS/info/assign/Microsoft - MSX.ini
@@ -1,9 +1,12 @@
 [global]
 name=Microsoft - MSX
-default=fMSX
+default=blueMSX
 catalogue=Microsoft - MSX
 lookup=0
 governor=ondemand
+
+[blueMSX]
+core=bluemsx_libretro.so
 
 [fMSX]
 core=fmsx_libretro.so


### PR DESCRIPTION
Included the blueMSX core option and made it default, since the required BIOS files are already included within muOS. while fMSX needs the user to provide its BIOS.