### PR TITLE
Update and rename MSX-SVI-ColecoVision-SG1000.ini to SVI-ColecoVision…

### DIFF
--- a/init/MUOS/info/assign/SVI-ColecoVision-SG1000.ini
+++ b/init/MUOS/info/assign/SVI-ColecoVision-SG1000.ini
@@ -1,7 +1,7 @@
 [global]
-name=MSX-SVI-ColecoVision-SG1000
+name=SVI-ColecoVision-SG1000
 default=blueMSX
-catalogue=MSX-SVI-ColecoVision-SG1000
+catalogue=SVI-ColecoVision-SG1000
 lookup=0
 governor=ondemand
 


### PR DESCRIPTION
…-SG1000.ini

As MSX has his own assign file, the blueMSX core was added to "Microsoft - MSX.ini" and the MSX naming scheme was removed from this assign file and from this catalogue. This way we don't have a double entry for MSX that could cause confusion.