### PR TITLE
Use RGB as low battery indicator

### DIFF
--- a/script/system/lowpower.sh
+++ b/script/system/lowpower.sh
@@ -5,11 +5,18 @@
 while :; do
 	if [ "$(cat "$(GET_VAR "device" "battery/charger")")" -eq 0 ]; then
 		if [ "$(cat "$(GET_VAR "device" "battery/capacity")")" -le "$(GET_VAR "global" "settings/power/low_battery")" ]; then
+			if [ "$(GET_VAR device led/rgb)" -eq 1 ]; then
+				/opt/muos/device/current/script/led_control.sh 2 255 255 0 0
+			fi					
 			echo 1 >"$(GET_VAR "device" "led/low")"
 			sleep 0.5
 			echo 0 >"$(GET_VAR "device" "led/low")"
+		else
+			if [ "$(GET_VAR device led/rgb)" -eq 1 ]; then
+				/run/muos/storage/theme/active/rgb/rgbconf.sh
+			fi
 		fi
-	fi
 
-	sleep 10
+		sleep 10
+	fi
 done &

--- a/script/system/lowpower.sh
+++ b/script/system/lowpower.sh
@@ -16,7 +16,6 @@ while :; do
 				/run/muos/storage/theme/active/rgb/rgbconf.sh
 			fi
 		fi
-
-		sleep 10
 	fi
+ 	sleep 10
 done &


### PR DESCRIPTION
RG40XXV and H have battery indicator not visible while playing since they are on the top of the device. Because of this default red flashing on low battery is hard to notice. I've edited the lowpower.sh file to use the RGB on the stick as low battery indicator.