### PR TITLE
Change Pipewire to use different output sample rates

### DIFF
--- a/config/pipewire.conf
+++ b/config/pipewire.conf
@@ -27,7 +27,8 @@ context.properties = {
 
     ## Properties for the DSP configuration.
     default.clock.rate          = 48000
-    default.clock.allowed-rates = [ 48000 ]
+    default.clock.allowed-rates = [ 32000, 44100, 48000 ]
+    resample.quality = 4
     default.clock.quantum       = 512
     default.clock.min-quantum   = 256
     default.clock.max-quantum   = 8192


### PR DESCRIPTION
This should avoid resampling in the most common cases. This fixes some audio sync issues with some ports like GTA3/VC