### PR TITLE
add midssio to skipped files

### DIFF
--- a/init/MUOS/info/skip.ini
+++ b/init/MUOS/info/skip.ini
@@ -4,6 +4,7 @@ img*
 control.txt
 neogeo.zip
 pgm.zip
+midissio.zip
 *.bps*
 *.dat*
 *.ips*

--- a/init/MUOS/info/skip.ini
+++ b/init/MUOS/info/skip.ini
@@ -4,7 +4,7 @@ img*
 control.txt
 neogeo.zip
 pgm.zip
-midissio.zip
+midssio.zip
 *.bps*
 *.dat*
 *.ips*


### PR DESCRIPTION
midssio is a bios file for midway arcade systems, and can't be executed directly. similar to neogeo.zip and pgm.zip