### PR TITLE
Add pause menu exit functionality to ext-ppsspp launch script

### DIFF
--- a/script/launch/ext-ppsspp.sh
+++ b/script/launch/ext-ppsspp.sh
@@ -31,7 +31,7 @@ cd "$EMUDIR" || exit
 
 sed -i '/^GraphicsBackend\|^FailedGraphicsBackends\|^DisabledGraphicsBackends/d' "$EMUDIR/.config/ppsspp/PSP/SYSTEM/ppsspp.ini"
 
-HOME="$EMUDIR" SDL_ASSERT=always_ignore SDL_GAMECONTROLLERCONFIG=$(grep "muOS-Keys" "/opt/muos/device/current/control/gamecontrollerdb_retro.txt") ./PPSSPP "$FILE"
+HOME="$EMUDIR" SDL_ASSERT=always_ignore SDL_GAMECONTROLLERCONFIG=$(grep "muOS-Keys" "/opt/muos/device/current/control/gamecontrollerdb_retro.txt") ./PPSSPP --pause-menu-exit "$FILE"
 
 [ "$(GET_VAR "global" "settings/hdmi/enabled")" -eq 1 ] && SCREEN_TYPE="external" || SCREEN_TYPE="internal"
 FB_SWITCH "$(GET_VAR "device" "screen/$SCREEN_TYPE/width")" "$(GET_VAR "device" "screen/$SCREEN_TYPE/height")" 32


### PR DESCRIPTION
Currently, MustardOS quits to the PPSSPP main menu when pressing the "Exit to menu" button in the pause menu, regardless of if games are launched through the frontend. 

PPSSPP has a command-line argument to change this behavior, which is added to the launch script in this change. Reference info about this commend line argument can be found here: https://www.ppsspp.org/docs/reference/command-line/

Following this change, games launching EXT-PPSSPP through the frontend will now quit the emulator instead of simply quitting to the PPSSPP main menu when the "Exit" button is clicked on the PPSSPP pause menu.