### PR TITLE
Change default GBA core to mGBA

### DIFF
--- a/init/MUOS/info/assign/Nintendo Game Boy Advance.ini
+++ b/init/MUOS/info/assign/Nintendo Game Boy Advance.ini
@@ -1,6 +1,6 @@
 [global]
 name=Nintendo Game Boy Advance
-default=gpSP
+default=mGBA
 catalogue=Nintendo Game Boy Advance
 lookup=0
 governor=ondemand


### PR DESCRIPTION
mGBA has finally fixed long standing issues that prevented me from making them default.
We still lose GBA Wireless Adapter support, but romhack compatibility increases.