### PR TITLE
fix launching applications when using passlock

### DIFF
--- a/script/mux/launch.sh
+++ b/script/mux/launch.sh
@@ -5,6 +5,7 @@
 ACT_GO=/tmp/act_go
 ROM_GO=/tmp/rom_go
 GVR_GO=/tmp/gvr_go
+MUX_LAUNCHER_AUTH=/tmp/mux_launcher_auth
 
 GPTOKEYB_BIN=gptokeyb2
 GPTOKEYB_DIR="$(GET_VAR "device" "storage/rom/mount")/MUOS/emulator/gptokeyb"
@@ -15,9 +16,10 @@ export EVSIEVE_BIN=evsieve
 export EVSIEVE_DIR="/opt/muos/bin"
 export EVSIEVE_CONFDIR="/opt/muos/config/evsieve"
 
-if [ "$(GET_VAR "global" "settings/advanced/lock")" -eq 1 ]; then
-	nice --20 /opt/muos/extra/muxpass -t launch
-	if [ "$?" = 2 ]; then
+if [ "$(GET_VAR "global" "settings/advanced/lock")" -eq 1 ] && [ ! -e "$MUX_LAUNCHER_AUTH" ]; then
+	EXEC_MUX "" "muxpass" -t launch
+	[ "$EXIT_STATUS" -eq 1 ] && touch "$MUX_LAUNCHER_AUTH"
+	if [ "$EXIT_STATUS" = 2 ]; then
 		rm "$ROM_GO"
 		echo explore >"$ACT_GO"
 		exit

--- a/script/var/func.sh
+++ b/script/var/func.sh
@@ -8,6 +8,7 @@ CSI="${ESC}[38;5;"
 
 SAFE_QUIT=/tmp/safe_quit
 EXIT_STATUS=0
+PREVIOUS_MODULE=""
 
 EXEC_MUX() {
 	[ -f "$SAFE_QUIT" ] && rm "$SAFE_QUIT"
@@ -22,6 +23,7 @@ EXEC_MUX() {
 	nice --20 "/opt/muos/extra/$MODULE" "$@"
 
 	while [ ! -f "$SAFE_QUIT" ]; do sleep 0.1; done
+	PREVIOUS_MODULE="$MODULE"
 	EXIT_STATUS=$(head -n 1 "$SAFE_QUIT")
 }
 


### PR DESCRIPTION
* updated so that when turning passlock on in advance settings it will not prompt for password exiting config
* updated to only prompt for password first time running application or content.
* updated to refresh authenticated status if passlock is turned off and on again