### PR TITLE
Issue report: RG35XXSP refuses to charge after sleep

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ This repository holds all of the key infrastructure of mustardOS (muOS):
 * `extra`: The frontend files which are compiled from https://github.com/MustardOS/frontend
 * `init`: Content partition filesystem which is moved on first install
 * `script`: Various POSIX compliant script files which is the backbone of muOS
+ 


### PR DESCRIPTION
Hi, since you don't have any way to report issues and no ways to communicate I'm creating a dummy merge request to report issue.

My RG35XXSP refuses to charge after going to sleep. It charges just fine when just powered on or rebooted but once it goes to sleep (Sleep Suspend in power options) immideately after wake up it stops charging (charge LED starts blinking)