### PR TITLE
Set RG35XX-Plus to use rtc0 for wake instead of rtc1

### DIFF
--- a/device/rg35xx-plus/config.ini
+++ b/device/rg35xx-plus/config.ini
@@ -10,7 +10,7 @@ hdmi = 1
 event = 4
 debugfs = 1
 rtc_clock = /dev/rtc0
-rtc_wake = /sys/class/rtc/rtc1
+rtc_wake = /sys/class/rtc/rtc0
 rumble = /sys/class/power_supply/axp2202-battery/moto
 udc = 5100000.udc-controller
 


### PR DESCRIPTION
Installing PIXIE broke sleep to shutdown on my RG35XX-Plus, but not on my RG28XX. I did some digging and found that while `/sys/class/rtc/rtc1` exists on the RG28XX, it does not exist on my RG35XX-Plus. I don't have multiple devices to check if this is always true, but I noticed some other people on the Discord were having the same issue so I'd guess it isn't just me.

This switches it to use `rtc0` instead, which does exist. I don't understand enough about how everything is wired together to know if this is a bad idea, but it fixed the issue when I made this change directly to `/opt/muos/device/rg35xx-plus/config.ini` on my device.