### PR TITLE
Add missing "megaduck" folder to default assign.json

### DIFF
--- a/init/MUOS/info/assign.json
+++ b/init/MUOS/info/assign.json
@@ -200,6 +200,7 @@
     "megadrive": "sega mega drive - genesis.ini",
     "megadrivecd": "sega mega cd - sega cd.ini",
     "megadrivehacks": "sega mega drive - genesis.ini",
+    "megaduck": "mega duck.ini",
     "mgba": "nintendo game boy advance.ini",
     "microsoftdos": "dos.ini",
     "microsoftmsx": "microsoft - msx.ini",


### PR DESCRIPTION
Very straight forward: There was no megaduck folder in the default assign.json file. I added it and set correct .ini file.