### PR TITLE
Add support for folder-style PSP games

### DIFF
--- a/script/launch/ext-ppsspp.sh
+++ b/script/launch/ext-ppsspp.sh
@@ -17,6 +17,28 @@ PPSSPP_DIR="$(GET_VAR "device" "storage/rom/mount")/MUOS/emulator/ppsspp"
 HOME="$PPSSPP_DIR"
 export HOME
 
+case "$FILE" in
+	*.psp)
+		# Mechanism to launch PSP folder-style games
+		GAME=$(basename "$FILE" | sed -e 's/\.[^.]*$//')
+		GAMEDIR=$(dirname "$FILE")
+		if [ -e "$PPSSPP_DIR/.config/ppsspp/PSP/GAME/$GAME/EBOOT.PBP" ]; then
+			FILE="$PPSSPP_DIR/.config/ppsspp/PSP/GAME/$GAME/EBOOT.PBP"
+		else
+			GAMESUBDIR=$(find "$GAMEDIR" -maxdepth 2 -type d \( -iname "$GAME" -o -iname ".$GAME" \) )
+			if [ -n "$GAMESUBDIR" ]; then
+				if [ -e "$GAMESUBDIR/EBOOT.PBP" ]; then
+					FILE="$GAMESUBDIR/EBOOT.PBP"
+				else
+					echo >&2 "Game folder $GAMESUBDIR exists, but no EBOOT.PBP found"
+				fi
+			else
+				echo >&2 "Game folder not found for $GAME"
+			fi
+		fi
+		;;
+esac
+
 if [ "$(GET_VAR "global" "boot/device_mode")" -eq 1 ]; then
 	SDL_HQ_SCALER=2
 	SDL_ROTATION=0


### PR DESCRIPTION
PSP games in a folder with an EBOOT.PBP file aren’t as well supported today as
games as a disk image, as they have to be placed in the PPSSPP memstick folder,
then you have to run PPSSPP and launch it from within the emulator. While this
works, it isn’t well integrated like other content is in muOS. While most
release games can be trivially converted to a disk image format, it doesn’t seem
like this is a good option for homebrew games like Minecraft PSP or others, so
those have to be run directly from PPSSPP at this time.

Instead, we can make use of a hidden folder and a placeholder file the way it’s
done for some other systems like ScummVM. If a `<game name>.psp` file is used,
it will check for a hidden game folder of the same name, a folder in .hidden/, or
a folder in the PPSSPP memstick folder, and run the emulator with that instead.
This lets the user play homebrew PSP games directly from the content explorer
rather than launching them directly from PPSSPP.
