### PR TITLE
Update the fix for launching ppsspp(explore content) after Vulkan is …

### DIFF
--- a/script/launch/ext-ppsspp.sh
+++ b/script/launch/ext-ppsspp.sh
@@ -33,6 +33,7 @@ case "$(GET_VAR "device" "board/name")" in
 
 		sed -i '/^GraphicsBackend\|^FailedGraphicsBackends\|^DisabledGraphicsBackends/d' \
 			"$PPSSPP_DIR/.config/ppsspp/PSP/SYSTEM/ppsspp.ini"
+   		rm -f "$PPSSPP_DIR/.config/ppsspp/PSP/SYSTEM/FailedGraphicsBackends.txt"
 		;;
 	tui*)
 		PPSSPP_DIR="${PPSSPP_DIR}/tui"


### PR DESCRIPTION
…set on RG devices.

Latest ppsspp builds create an external txt file for the FailedGraphicsBackends message that also need to be removed in conjunction with the entry in the ppsspp.ini file so it can default to opengl again.