### PR TITLE
Add support for ext4 mounting for both SDCard 2 and USB

### DIFF
--- a/script/mount/sdcard.sh
+++ b/script/mount/sdcard.sh
@@ -25,6 +25,7 @@ MOUNT_DEVICE() {
 
 	case "$FS_TYPE" in
 		vfat | exfat) FS_OPTS=rw,utf8,noatime,nofail ;;
+		ext4) FS_OPTS=rw,noatime,nofail ;;
 		*) return ;;
 	esac
 

--- a/script/mount/usb.sh
+++ b/script/mount/usb.sh
@@ -24,6 +24,7 @@ MOUNT_DEVICE() {
 
 	case "$FS_TYPE" in
 		vfat | exfat) FS_OPTS=rw,utf8,noatime,nofail ;;
+		ext4) FS_OPTS=rw,noatime,nofail ;;
 		*) return ;;
 	esac
 

--- a/script/system/fixdisk.sh
+++ b/script/system/fixdisk.sh
@@ -24,6 +24,10 @@ dmesg | grep 'Please run fsck' | while read -r line; do
 					printf "Filesystem is exFAT. Running 'fsck.exfat' on /dev/%s\n" "$DEVICE"
 					fsck.exfat "/dev/$DEVICE" >"$LOGFILE" 2>&1
 					;;
+				ext4)
+					printf "Filesystem is ext4. Running 'fsck.ext4' on /dev/%s\n" "$DEVICE"
+					fsck.ext4 -y "/dev/$DEVICE" > "$LOGFILE" 2>&1
+					;;
 				*)
 					printf "Unknown or unsupported filesystem type '%s' for /dev/%s. Skipping!\n" "$FS_TYPE" "$DEVICE"
 					;;


### PR DESCRIPTION
As the title says.

This allows mounting ext4 formatted removable card and key.
ext4 is a journal filesystem that, hopefully, doesn't get corrupted on (unwanted) reset or unexpected power loss.


It doesn't change much for Windows and Mac user. But for linux users, it adds a very welcome feature for card stability.