### PR TITLE
Add Geolith core override

### DIFF
--- a/init/MUOS/info/config/Geolith/Geolith.cfg
+++ b/init/MUOS/info/config/Geolith/Geolith.cfg
@@ -1,0 +1,1 @@
+aspect_ratio_index = "22"


### PR DESCRIPTION
Set default aspect ratio to "Core Provided" so the user can properly adjust it in the Geolith core options.