### PR TITLE
Refactor Syncthing scan logic and improve shutdown

### DIFF
--- a/init/MUOS/task/Manual Syncthing Scan.sh
+++ b/init/MUOS/task/Manual Syncthing Scan.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# HELP: Manual Syncthing Scan
+# ICON: backup
+
+LOGFILE="/tmp/tt_manual_sync.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+. /opt/muos/script/var/func.sh
+FRONTEND stop
+
+# START SCRIPT
+echo "Starting Manual Syncthing Scan at $(date +"%Y-%m-%d %H:%M:%S")"
+
+# Check if Syncthing is enabled in config
+SYNCTHING_ENABLED=$(GET_VAR "config" "web/syncthing")
+# Check if network is up
+NETWORK_STATE=$(cat "$(GET_VAR "device" "network/state")")
+ERROR_FLAG=0
+
+if [ -z "$SYNCTHING_ENABLED" ]; then
+    echo "Error: Could not determine if Syncthing is enabled. Skipping scan."
+    ERROR_FLAG=1
+elif [ -z "$NETWORK_STATE" ]; then
+    echo "Error: Could not determine network state. Skipping scan."
+    ERROR_FLAG=1
+elif [ "$SYNCTHING_ENABLED" -eq 1 ] && [ "$NETWORK_STATE" = "up" ]; then
+    SYNCTHING_API=$(sed -n 's:.*<apikey>\([^<]*\)</apikey>.*:\1:p' /run/muos/storage/syncthing/config.xml)
+fi
+
+if [ ERROR_FLAG -eq 0 ] && [ -z "$SYNCTHING_API" ]; then 
+    echo "Error: Syncthing API key not found or config file is missing/malformed. Skipping scan."
+    ERROR_FLAG=1
+else
+    # Get list of folder IDs from Syncthing API
+    FOLDER_IDS=$(curl -s -H "X-API-Key: $SYNCTHING_API" "http://localhost:7070/rest/config" | jq -r '.folders[].id')
+    for FOLDER_ID in $FOLDER_IDS; do
+        echo "[INFO] Starting scan for folder: $FOLDER_ID"
+        # Initiate scan (non-blocking)
+        curl -s -X POST -H "X-API-Key: $SYNCTHING_API" "http://localhost:7070/rest/db/scan?folder=$FOLDER_ID" >/dev/null 2>&1 &
+        sleep 1
+    done
+fi
+
+if [ $ERROR_FLAG -eq 1 ]; then
+    echo "Error occurred during manual Syncthing scan."
+fi
+
+echo "Sync Filesystem"
+sync
+
+echo "Manual Syncthing Scan completed at $(date +"%Y-%m-%d %H:%M:%S")"
+/opt/muos/bin/toybox sleep 2
+
+FRONTEND start task
+exit 0

--- a/script/mux/launch.sh
+++ b/script/mux/launch.sh
@@ -99,10 +99,11 @@ SCREEN_TYPE="internal"
 [ "$(GET_VAR "config" "boot/device_mode")" -eq 1 ] && SCREEN_TYPE="external"
 FB_SWITCH "$(GET_VAR "device" "screen/$SCREEN_TYPE/width")" "$(GET_VAR "device" "screen/$SCREEN_TYPE/height")" 32
 
-if [ "$(GET_VAR "config" "web/syncthing")" -eq 1 ] && [ "$(cat "$(GET_VAR "device" "network/state")")" = "up" ]; then
-	SYNCTHING_API=$(sed -n 's:.*<apikey>\([^<]*\)</apikey>.*:\1:p' /run/muos/storage/syncthing/config.xml)
-	curl -X POST -H "X-API-Key: $SYNCTHING_API" "localhost:7070/rest/db/scan"
-fi
+#TODO: Re-enable in the future with a config module
+#if [ "$(GET_VAR "config" "web/syncthing")" -eq 1 ] && [ "$(cat "$(GET_VAR "device" "network/state")")" = "up" ]; then
+#	SYNCTHING_API=$(sed -n 's:.*<apikey>\([^<]*\)</apikey>.*:\1:p' /run/muos/storage/syncthing/config.xml)
+#	curl -X POST -H "X-API-Key: $SYNCTHING_API" "localhost:7070/rest/db/scan"
+#fi
 
 if [ -s "$PC_IP" ]; then
 	python "$(GET_VAR "device" "storage/rom/mount")/MUOS/discord/discord_presence_handheld.py" "$(cat "$PC_IP")" --clear

--- a/script/mux/quit.sh
+++ b/script/mux/quit.sh
@@ -88,12 +88,13 @@ HALT_SYSTEM() {
 			;;
 	esac
 
+	#TODO: Re-enable in the future using a config module
 	# Run syncthing scanner if enabled
-	LOG_INFO "$0" 0 "QUIT" "Running syncthing scanner if enabled"
-	if [ "$(GET_VAR "config" "web/syncthing")" -eq 1 ] && [ "$(cat "$(GET_VAR "device" "network/state")")" = "up" ]; then
-		SYNCTHING_API=$(sed -n 's:.*<apikey>\([^<]*\)</apikey>.*:\1:p' /run/muos/storage/syncthing/config.xml)
-		curl -X POST -H "X-API-Key: $SYNCTHING_API" "localhost:7070/rest/db/scan"
-	fi
+	#LOG_INFO "$0" 0 "QUIT" "Running syncthing scanner if enabled"
+	#if [ "$(GET_VAR "config" "web/syncthing")" -eq 1 ] && [ "$(cat "$(GET_VAR "device" "network/state")")" = "up" ]; then
+	#	SYNCTHING_API=$(sed -n 's:.*<apikey>\([^<]*\)</apikey>.*:\1:p' /run/muos/storage/syncthing/config.xml)
+	#	curl -X POST -H "X-API-Key: $SYNCTHING_API" "localhost:7070/rest/db/scan"
+	#fi
 }
 
 [ "$#" -eq 2 ] || USAGE

--- a/script/system/halt.sh
+++ b/script/system/halt.sh
@@ -160,6 +160,16 @@ FIND_PROCS() {
 	return 1
 }
 
+# Avoid hangups from syncthing if it's running.
+if [ "$(GET_VAR "config" "web/syncthing")" -eq 1 ]; then
+	LOG_INFO "$0" 0 "HALT" "Shutdown Syncthing gracefully"
+	SYNCTHING_API=$(sed -n 's:.*<apikey>\([^<]*\)</apikey>.*:\1:p' /run/muos/storage/syncthing/config.xml)
+	CURL_OUTPUT=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "X-API-Key: $SYNCTHING_API" "http://localhost:7070/rest/system/shutdown")
+	if [ "$CURL_OUTPUT" -eq 200 ]; then
+		LOG_INFO "$0" 0 "HALT" "Syncthing shutdown request sent successfully."
+	fi
+fi
+
 # Muting audio so we don't get any of those nasty clicks from the speaker.
 wpctl set-mute @DEFAULT_AUDIO_SINK@ "1"
 


### PR DESCRIPTION
Moved manual Syncthing scan to a dedicated script and commented out automatic scan triggers in launch.sh and quit.sh. Added logic in halt.sh to gracefully shut down Syncthing if enabled and network is up.