### PR TITLE
Optimize content search

### DIFF
--- a/script/mux/find.sh
+++ b/script/mux/find.sh
@@ -12,53 +12,91 @@ USAGE() {
 . /opt/muos/script/var/func.sh
 
 RESULTS_JSON="$(GET_VAR "device" "storage/rom/mount")/MUOS/info/search.json"
-FRIENDLY_JSON="/run/muos/storage/info/name/general.json"
 SKIP_FILE="$(GET_VAR "device" "storage/sdcard/mount")/MUOS/info/skip.ini"
 [ ! -s "$SKIP_FILE" ] && SKIP_FILE="$(GET_VAR "device" "storage/rom/mount")/MUOS/info/skip.ini"
-
-TMP_DIR=$(mktemp -d)
-trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
-
-TMP_FRIENDLY="/tmp/f_result.json"
-TMP_FRIENDLY_FILES="$TMP_DIR/f_files.txt"
-TMP_FILES="$TMP_DIR/files.txt"
-TMP_RESULTS="$TMP_DIR/results.json"
 
 S_TERM="$1"
 
 # Shift one argument over so we are left with only directories to search
 shift
 
-# Generate friendly name JSON so we can use that for the search results for quicker parsing
-if [ -f "$FRIENDLY_JSON" ]; then
-	/opt/muos/bin/rg -i "$S_TERM" "$FRIENDLY_JSON" |
-		sed -e '1s/^/{\n/' -e '$s/,$//' -e '$a}' >"$TMP_FRIENDLY"
-	jq -r 'keys[]' "$TMP_FRIENDLY" >"$TMP_FRIENDLY_FILES"
-else
-	printf "{}" >"$TMP_FRIENDLY"
-	: >"$TMP_FRIENDLY_FILES"
-fi
+# Convert directories array to JSON
+directories=$(printf '%s\n' "$@" | jq -R . | jq -s .)
 
-# Create and populate JSON structure for parsing in muxsearch
-jq -n --arg lookup "$S_TERM" '{lookup: $lookup, directories: [], folders: {}}' >"$TMP_RESULTS"
+# Process all directories and create JSON structure in a single pipeline
+{
+	# Process each directory and output all matching files
+	for S_DIR in "$@"; do
+		# rg --files: List all files in directory (no content search, just enumerate files)
+		# --color=never: Disable ANSI color codes (clean output for piping)
+		# --ignore-file: Use skip.ini to exclude unwanted files/directories
+		# 2>/dev/null: Suppress permission denied errors
+		/opt/muos/bin/rg --color=never --files "$S_DIR" --ignore-file "$SKIP_FILE" 2>/dev/null |
 
-# Okay now we'll go through each of the requested directories and find content based on the search term
-for S_DIR in "$@"; do
-	/opt/muos/bin/rg --files "$S_DIR" --ignore-file "$SKIP_FILE" 2>/dev/null |
-		/opt/muos/bin/rg --pcre2 -i "/(?!.*\/).*$S_TERM" |
-		sed "s|^$S_DIR/||" | sort -fu >>"$TMP_FILES" # yeah sort fuck you too
+		# rg (second call): Filter filenames by search term
+		# --color=never: Disable ANSI color codes for clean piping
+		# --pcre2: Use Perl-compatible regex engine (supports advanced patterns)
+		# -i: Case-insensitive matching
+		# "/(?!.*\/).*$S_TERM": Regex to match only filenames, not directory paths
+		#   /: Match paths ending with slash (file paths)
+		#   (?!.*\/): Negative lookahead - ensure no slash after this point
+		#   .*$S_TERM: Match any characters followed by search term
+		# || true: Prevent script exit when no matches found (rg exits with status 1)
+		/opt/muos/bin/rg --color=never --pcre2 -i "/(?!.*\/).*$S_TERM" || true
+	done
+} |
+# Input to jq: File paths (one per line)
+# Example:
+#   /mnt/sdcard/ROMS/Pico-8/awesome_platform_adventure.p8
+#   /mnt/sdcard/ROMS/Ports/open_source_adventure.zip
+# jq -R: Read each line as string instead of JSON
+# jq -s: read all inputs into an array and use it as
+# the single input value
+jq -R . | jq -s --arg lookup "$S_TERM" --argjson directories "$directories" '
+	# map(...): Transform each file path string into {dir:..., file:...} object
+	#   split("/"): Split path by "/" into array of components
+	#   {dir: (.[:-1] | join("/")), file: .[-1]}: Create object where:
+	#     .[:-1]: All elements except last (directory components)
+	#     join("/"): Rejoin directory components with "/"
+	#    .[-1]: Last element (filename)
+	map(split("/") | {dir: (.[:-1] | join("/")), file: .[-1]}) |
 
-	jq --arg dir "$S_DIR" '.directories += [$dir]' "$TMP_RESULTS" >"$TMP_RESULTS.dirlist"
-	mv "$TMP_RESULTS.dirlist" "$TMP_RESULTS"
-done
+	# group_by(.dir): Group all objects by their "dir" field (sorted)
+	# Creates array of arrays, each sub-array contains objects with same directory
+	group_by(.dir) |
 
-# Time to make the JSON results file with everything above!
-while IFS= read -r RESULT; do
-	jq --arg dir "$(dirname "$RESULT")" --arg file "$(basename "$RESULT")" \
-		'(.folders[$dir].content += [$file]) //(.folders[$dir] = { content: [$file] })' \
-		"$TMP_RESULTS" >"$TMP_RESULTS.result"
-	mv "$TMP_RESULTS.result" "$TMP_RESULTS"
-done <"$TMP_FILES"
+	# map({...}): Transform each group into key-value pair object
+	map({
+		# key: .[0].dir: Use directory from first object in group (all have same dir)
+		key: .[0].dir,
 
-# And now we'll sort out the entries within each key
-jq '.folders |= (to_entries | sort_by(.key) | from_entries)' "$TMP_RESULTS" >"$RESULTS_JSON"
+		# value: {content: [...]}: Create object with "content" array
+		# map(.file): Extract "file" field from each object in group
+		# | sort: Sort filenames alphabetically
+		value: {content: map(.file) | sort}
+	}) |
+
+	# from_entries: Convert array of {key:..., value:...} objects into single object
+	# Each key becomes a property name, each value becomes the property value
+	from_entries |
+
+	# Final JSON structure: Create object with lookup term, directories, and folders
+	#   $lookup: Use the lookup variable passed from shell
+	#   $directories: Use the directories array passed from shell
+	#   .: Reference the current grouped folders object
+	#
+	# Example:
+	#   {
+	#     "lookup": "adventure",
+	#     "directories": ["/mnt/sdcard/ROMS"],
+	#     "folders": {
+	#       "/mnt/sdcard/ROMS/Pico-8": {
+	#         "content": ["awesome_platform_adventure.p8"]
+	#       },
+	#       "/mnt/sdcard/ROMS/Ports": {
+	#         "content": ["open_source_adventure.zip"]
+	#       }
+	#     }
+	#   }
+	{lookup: $lookup, directories: $directories, folders: .}
+' > "$RESULTS_JSON"


### PR DESCRIPTION
# Problem

The original `find.sh` script had several inefficiencies:

1. **Multiple temporary files**: Used 4+ temp files for intermediate processing
2. **O(n) jq invocations**: Called jq once per directory and once per matching file
3. **Complex pipeline**: Multiple file reads and writes in loops

# Solution

#### 1. Eliminated Multiple Temporary Files
**Before**: Used 4+ temp files (`TMP_FILES`, `TMP_RESULTS`, `TMP_RESULTS.dirlist`, `TMP_RESULTS.result`)
**After**: Single pipeline with no intermediate files (i.e. minimal I/O)

#### 2. Reduced jq Invocations from O(n) to O(1)
**Before**:
- 1 initial jq call to create structure
- 1 jq call per directory (to add to directories array)
- 1 jq call per matching file (could be hundreds)
- 1 final jq call to sort

**After**: Single jq operation produces `folders` result, interpolates the end result directly.

#### 3. Streamlined Data Processing Pipeline
**Before**: `rg -> rg -> sed -> sort -> while read -> jq (per file)`
**After**: `rg -> rg -> jq`

# Benchmarks

* Searching for increasingly narrow search terms yields results in just milliseconds on average.
* Searched "e" on an English language rom set (13k raw hits) to test worst case performance.

```
Term   Script         Min Time    Max Time   Avg Time   Median Time  Performance
--------------------------------------------------------------------------------------------
zelda  find-old.sh    0.1816s     0.2134s    0.1947s    0.1953s          
       find-new.sh    0.0305s     0.0342s    0.0321s    0.0317s           
       Improvement:                                                  +83.00% (6.0x faster)
--------------------------------------------------------------------------------------------
tennis find-old.sh    0.5354s     0.5532s    0.5435s    0.5392s         
       find-new.sh    0.0315s     0.0362s    0.0336s    0.0335s              
       Improvement:                                                  +93.00% (16.1x faster)
--------------------------------------------------------------------------------------------
the    find-old.sh    13.2671s    18.9075s   15.6527s   15.3009s              
       find-new.sh    0.0518s     0.0618s    0.0542s    0.0523s              
       Improvement:                                                  +99.00% (288.7x faster)
--------------------------------------------------------------------------------------------
e      find-old.sh    157.4212s   168.5029s  162.9513s  163.5174s            
       find-new.sh    0.1599s     0.3567s    0.2217s    0.1967s          
       Improvement:                                                  +99.00% (735.0x faster)
--------------------------------------------------------------------------------------------
```

# Notes 

* Note this was performed on Apple M3 Pro, searching 13k+ synthetic rom files
* On an RG35xx Plus performance is > 2x slower than these numbers 🙃 