### PR TITLE
Update drastic trngaje layout.json

### DIFF
--- a/init/MUOS/emulator/drastic-trngaje/resources/bg/640x480/layout.json
+++ b/init/MUOS/emulator/drastic-trngaje/resources/bg/640x480/layout.json
@@ -221,7 +221,7 @@
     "name":"hh0",
     "bg":"bg_hh0.png",
     "type":2,
-    "rotate":90,
+    "rotate":270,
 
     "screen0_x":0,
     "screen0_y":26,


### PR DESCRIPTION
For devices with analog sticks running at 640x480 resolution:

In layout #13 (rotation mode), the rotation was changed from 90° to 270°. This adjustment aligns the controls correctly with the screen, fixing the previous mismatch.