### PR TITLE
Update global.ini with friendly name for Atari 2600

### DIFF
--- a/init/MUOS/info/assign/Atari 2600/global.ini
+++ b/init/MUOS/info/assign/Atari 2600/global.ini
@@ -7,6 +7,7 @@ governor=ondemand
 
 [friendly]
 twentysixhundred
+atari
 atari2600
 a2600
 2600


### PR DESCRIPTION
Related to pull request #606. Needed to add only "atari" as both "ms" and "segacd" are already present in their relevant global.ini files.