### PR TITLE
Addressing unreliable network 

### DIFF
--- a/script/system/network.sh
+++ b/script/system/network.sh
@@ -187,6 +187,10 @@ case "$1" in
 	connect)
 		case "$(GET_VAR "device" "board/name")" in
 			tui*) /opt/muos/script/device/module.sh load-network ;;
+			rg*)
+				if ! [ -d "/sys/bus/mmc/devices/mmc2:0001" ]; then
+					/opt/muos/script/device/module.sh reload-network
+				fi ;;
 			*) ;;
 		esac
 

--- a/script/system/startup.sh
+++ b/script/system/startup.sh
@@ -168,9 +168,11 @@ fi
 
 (
 	LOG_INFO "$0" 0 "BOOTING" "Checking for Network Capability"
-	if [ "$CONNECT_ON_BOOT" -eq 1 ] && [ "$HAS_NETWORK" -eq 1 ]; then
+	if [ "$HAS_NETWORK" -eq 1 ]; then
 		/opt/muos/script/device/module.sh load-network
-		/opt/muos/script/system/network.sh connect &
+		if [ "$CONNECT_ON_BOOT" -eq 1 ]; then
+			/opt/muos/script/system/network.sh connect &
+		fi
 	fi
 ) &
 


### PR DESCRIPTION
These are mainly fixes I have tried on my RG35XX-SP to address the unreliable network loading.

I lost the original modifications I have made on 2508 so I am currently trying similar modifications to what I recall but adapting 2508.1 instead.

I will keep this as a draft until it satisfies the aim and while it's not confirmed to be sufficiently reliable.

Currently, I have addressed the following issues with those modifications : 
- Unable to scan for wifi
- Unable to connect to wifi
- Connecting to wifi is slow and the connection is not maintained once the user has left the wifi settings menu (partially)

I am trying to work out why the last point, where the wifi connection is not held when leaving the settings menu, is still happening on a cold boot with only the first commit. A reboot brings back functionality over 99% of the time (I don't think I've seen it be particularly stubborn).