### PR TITLE
Addressing cold boot network driver failure

### DIFF
--- a/script/device/module.sh
+++ b/script/device/module.sh
@@ -15,66 +15,7 @@ NET_IFACE=$(GET_VAR "device" "network/iface")
 NET_NAME=$(GET_VAR "device" "network/name")
 DNS_ADDR=$(GET_VAR "config" "network/dns")
 
-NET_COMPAT=$(GET_VAR "config" "network/compat")
-
 MAX_WAIT=30
-
-PRIME_IW_SCAN() {
-	IFACE=$1
-
-	ATTEMPTS=3
-	TIMEOUT=3
-
-	I=0
-	while [ "$I" -lt "$ATTEMPTS" ]; do
-		# Kick a passive scan in the background, because fucked if I know why
-		# first scan just sits there twiddling its thumbs!
-		iw dev "$IFACE" scan passive >/dev/null 2>&1 &
-		SCAN_PID=$!
-
-		ELAPSED=0
-		while kill -0 "$SCAN_PID" 2>/dev/null; do
-			[ "$ELAPSED" -ge "$TIMEOUT" ] && break
-			TBOX sleep 1
-			ELAPSED=$((ELAPSED + 1))
-		done
-
-		# If still running, abort politely then kill...
-		if kill -0 "$SCAN_PID" 2>/dev/null; then
-			iw dev "$IFACE" scan abort >/dev/null 2>&1
-			kill -TERM "$SCAN_PID" 2>/dev/null
-			wait "$SCAN_PID" 2>/dev/null
-		fi
-
-		I=$((I + 1))
-		TBOX sleep 1
-	done
-
-	iw dev "$IFACE" scan passive >/dev/null 2>&1
-	return 0
-}
-
-WAIT_FOR_LINK_READY() {
-	IFACE=$1
-
-	# Wait for carrier for ethernet connections
-	if [ -f "$SCN_PATH/$IFACE/carrier" ]; then
-		for _ in $(seq 1 "$MAX_WAIT"); do
-			[ "$(cat "$SCN_PATH/$IFACE/carrier" 2>/dev/null)" = "1" ] && return 0
-			TBOX sleep 1
-		done
-		return 1
-	else
-		# Verify we can scan with wlan
-		for _ in $(seq 1 "$MAX_WAIT"); do
-			iw dev "$IFACE" scan passive >/dev/null 2>&1 && return 0
-			TBOX sleep 1
-		done
-	fi
-
-	# If we cannot verify, do not block boot
-	return 0
-}
 
 FORCE_SDIO_AWAKE() {
 	# Keep SDIO from dozing while we bring Wi-Fi up
@@ -124,12 +65,18 @@ WAIT_FOR_IFACE() {
 LOAD_NETWORK() {
 	[ "$HAS_NETWORK" -eq 0 ] && return 0
 
-	if echo "$NET_NAME" | grep -q "8821cs"; then
-		modprobe -q -r 8821cs
-		udevadm settle --timeout=5
+	# We need this because the 8821cs driver likes to be persistent when it has failed
+	case "$BOARD_NAME" in
+		rg*)
+			modprobe -q -r "$NET_NAME"
+			udevadm settle --timeout=5
+			TBOX sleep 1
+			;;
+		*) ;;
+	esac
 
-		TBOX sleep 1
-	fi
+	# Should probably poke it again and make sure it's really awake before proceeding with final load
+	FORCE_SDIO_AWAKE
 
 	# Not really necessary for the TrimUI devices but because the H700 devices
 	# run this just before probing the network module we are going to add it
@@ -159,8 +106,6 @@ LOAD_NETWORK() {
 	ip link set "$NET_IFACE" up 2>/dev/null
 	[ -L "$SCN_PATH/$NET_IFACE/phy80211" ] && iw dev "$NET_IFACE" set power_save off 2>/dev/null
 
-	FORCE_SDIO_AWAKE
-
 	# Idle any secondary wlan interfaces (wlan1 etc.)
 	for N in "$SCN_PATH"/wlan*; do
 		[ -d "$N" ] || continue
@@ -168,12 +113,6 @@ LOAD_NETWORK() {
 		[ "$B" = "$NET_IFACE" ] && continue
 		ip link set "$B" down 2>/dev/null
 	done
-
-	# Wait for basic readiness...
-	if [ "$NET_COMPAT" -eq 1 ]; then
-		PRIME_IW_SCAN "$NET_IFACE"
-		WAIT_FOR_LINK_READY "$NET_IFACE" || return 1
-	fi
 
 	# Only touch resolv.conf if we actually have a DNS to set
 	if [ -n "$DNS_ADDR" ]; then
@@ -192,6 +131,12 @@ UNLOAD_NETWORK() {
 	udevadm settle --timeout=5
 
 	[ -f "$RESOLV_CONF.bak" ] && mv "$RESOLV_CONF.bak" "$RESOLV_CONF"
+}
+
+RELOAD_NETWORK() {
+	[ "$HAS_NETWORK" -eq 0 ] && return 0
+	UNLOAD_NETWORK
+	LOAD_NETWORK
 }
 
 LOAD_MODULES() {
@@ -225,5 +170,6 @@ case "$ACTION" in
 	unload) UNLOAD_MODULES ;;
 	load-network) [ "$FACTORY_RESET" -eq 0 ] && [ "$HAS_NETWORK" -eq 1 ] && LOAD_NETWORK ;;
 	unload-network) [ "$FACTORY_RESET" -eq 0 ] && [ "$HAS_NETWORK" -eq 1 ] && UNLOAD_NETWORK ;;
+	reload-network) [ "$FACTORY_RESET" -eq 0 ] && [ "$HAS_NETWORK" -eq 1 ] && RELOAD_NETWORK ;;
 	*) echo "Usage: $0 {load|unload|load-network|unload-network|reload-network}" >&2 && exit 1 ;;
 esac

--- a/script/system/startup.sh
+++ b/script/system/startup.sh
@@ -34,6 +34,7 @@ CONNECT_ON_BOOT=$(GET_VAR "config" "network/boot")
 USER_INIT=$(GET_VAR "config" "settings/advanced/user_init")
 FIRST_INIT=$(GET_VAR "config" "boot/first_init")
 USB_FUNCTION=$(GET_VAR "config" "settings/advanced/usb_function")
+NET_COMPAT=$(GET_VAR "config" "network/compat")
 
 # Enable rumble support - primarily used for TrimUI/RK3326 devices at the moment...
 case "$BOARD_NAME" in
@@ -52,6 +53,7 @@ esac
 
 LOG_INFO "$0" 0 "BOOTING" "Loading Device Specific Modules"
 /opt/muos/script/device/module.sh load
+/opt/muos/script/device/module.sh load-network
 
 if [ "$FIRST_INIT" -eq 0 ]; then
 	if [ "$FACTORY_RESET" -eq 1 ]; then
@@ -169,7 +171,11 @@ fi
 (
 	LOG_INFO "$0" 0 "BOOTING" "Checking for Network Capability"
 	if [ "$HAS_NETWORK" -eq 1 ]; then
-		/opt/muos/script/device/module.sh load-network
+		# we unload to help some RG* devices if Network Compatibility is enabled... and then reload to get our wifi
+		case "$BOARD_NAME" in
+			rg*) [ "$NET_COMPAT" -eq 1 ] && /opt/muos/script/device/module.sh reload-network ;;
+			*) ;;
+		esac
 		if [ "$CONNECT_ON_BOOT" -eq 1 ]; then
 			/opt/muos/script/system/network.sh connect &
 		fi


### PR DESCRIPTION
During a cold boot, the RTL and SDIO seem to be a little slow. The RTL driver tends to fail on a cold boot, resulting in no wlan interface to configure and connect to network with.

[This PR (629)](https://github.com/MustardOS/internal/pull/629) implemented a work around on network connection to still allow to connect to wifi even when that would happen. I was not satisfied with that solution simply because it would only reload the driver on wifi connection. Therefor, on a cold boot, wifi scanning would be unavailable until attempting to connect to wifi (whether or not it succeeds in connecting). This did not really prevent the device from connecting to the network, it was simply not *clean*.

With a little bit of experimentation, I believe I have found another crude solution to this. Using the new Network Compatiblity option, if the device is affected by this issue on cold boot, the driver can be loaded quickly at the beginning of the network module loading and interface configuration process. Whether or not the driver succeeds in loading is not a concern in this case as it's unloaded immediately afterwards for the rest of the loading process to happen normally.

I am guessing this prompts the RTL to power on, which it's sometime slow at doing, probably because of the SDIO. Unloading the driver and then loading it again with more thorough validation, followed by the configuration of the interface, seems to alleviate the issue on my device.

I am opening this PR as a draft to gather comments and reviews. I will experiment with my changes on my device for a while and will get it ready for merging once I'm confident the issue has been addressed.