### PR TITLE
Reducing Boot Times due to Network Module

### DIFF
--- a/script/device/module.sh
+++ b/script/device/module.sh
@@ -15,7 +15,8 @@ NET_IFACE=$(GET_VAR "device" "network/iface")
 NET_NAME=$(GET_VAR "device" "network/name")
 DNS_ADDR=$(GET_VAR "config" "network/dns")
 
-MAX_WAIT=30
+MAX_WAIT=5
+MAX_RETRY=$MAX_WAIT
 
 FORCE_SDIO_AWAKE() {
 	# Keep SDIO from dozing while we bring Wi-Fi up
@@ -119,6 +120,8 @@ LOAD_NETWORK() {
 		[ -f "$RESOLV_CONF" ] && cp "$RESOLV_CONF" "$RESOLV_CONF.bak"
 		printf "nameserver %s\n" "$DNS_ADDR" >"$RESOLV_CONF"
 	fi
+
+	return 0
 }
 
 UNLOAD_NETWORK() {
@@ -135,8 +138,15 @@ UNLOAD_NETWORK() {
 
 RELOAD_NETWORK() {
 	[ "$HAS_NETWORK" -eq 0 ] && return 0
-	UNLOAD_NETWORK
-	LOAD_NETWORK
+	# we reload the driver a couple of times because sometimes the RTL really wants to sleep
+	# it's okay to bully hardware... i think?
+	for _ in $(seq 1 $MAX_RETRY); do
+		UNLOAD_NETWORK
+		! LOAD_NETWORK && return 0
+		TBOX sleep 1
+	done
+	TBOX sleep 1
+	return 1
 }
 
 LOAD_MODULES() {


### PR DESCRIPTION
Now to form a trilogy of wifi patches...

I've reworked the reload function of the network module to include retries after figuring out by experimentation that the wait time for SDIO was greatly exaggerated. The time savings made by the reduction in waiting time allows me to reasonably implement a retry loop in the reloading of the network, increasing boot times again.

Since the loop only happens as many times as needed for a maximum number of attempts, the increase in boot times should be marginal unless the device really doesn't want to get out of bed.

Overall, this should reduce the time to boot caused by the network module. I also built infrastructure ready to use to decouple the maximum wait time and the maximum number of attempts, in the event that we may make these configurable.