### PR TITLE
Fixed track.sh to use user storage preferences instead of defaulting to SD1

### DIFF
--- a/script/mux/track.sh
+++ b/script/mux/track.sh
@@ -10,7 +10,7 @@ CORE="$2"
 FILE="$3"
 ACTION="$4"
 
-TRACK_JSON="$(GET_VAR "device" "storage/rom/mount")/MUOS/info/track/playtime_data.json"
+TRACK_JSON="$MUOS_STORE_DIR/info/track/playtime_data.json"
 TRACK_LOG="$(GET_VAR "device" "storage/rom/mount")/MUOS/log/playtime_error.log"
 
 if [ "$(GET_VAR "config" "boot/device_mode")" -eq 1 ]; then


### PR DESCRIPTION
I've noticed that even though my storage preferences for activity tracker data was set to SD2 (and correctly migrated to it), it didn't update since migration. I've poked around the track.sh code to find out that the JSON path was still using `$(GET_VAR "device" "storage/rom/mount")` to get the base path and therefore always used SD1 instead of SD2. 
I changed it to `$MUOS_STORE_DIR` and now it works correctly.

However, I'm not sure how `/run/muos/storage` behaves when `mkdir` below is invoked on it and directory needs to be created. Is `track` always there on SD1 as a fallback (and already linked in `/run/muos/storage/info`) or should I rewrite that folder creation part to make sure it creates a fallback directory on SD1?