### PR TITLE
Fix booting into last game using incorrect governor and incorrect control scheme

### DIFF
--- a/script/mux/frontend.sh
+++ b/script/mux/frontend.sh
@@ -98,12 +98,12 @@ if [ $SKIP -eq 0 ]; then
 				for TYPE in "governor" "control scheme"; do
 					case "$TYPE" in
 						"governor")
-							CONTENT_FILE="${BASE}.gov"
+							CONTENT_FILE="${DIR}/${BASE}.gov"
 							FALLBACK_FILE="${DIR}/core.gov"
 							OUTPUT_FILE="$GOV_GO"
 							;;
 						"control scheme")
-							CONTENT_FILE="${BASE}.con"
+							CONTENT_FILE="${DIR}/${BASE}.con"
 							FALLBACK_FILE="${DIR}/core.con"
 							OUTPUT_FILE="$CON_GO"
 							;;


### PR DESCRIPTION
## The issue:
On reboot, when MuOS is set to reboot into the last played game, It runs the governor for the **core** instead of the governor for the **game**.

## The fix:
*frontend.sh* got the correct basename of the file, but was not checking the correct directory.
The fix is simply fix the include the directory when assigning it to CONTENT_FILE.

#### PS:
The same issue presumably exists for the control scheme code, so I fixed that too.