### PR TITLE
Fixed .muxapp extraction path to use storage preference

### DIFF
--- a/script/mux/extract.sh
+++ b/script/mux/extract.sh
@@ -33,8 +33,6 @@ ARCHIVE_NAME="${ARCHIVE##*/}"
 FRONTEND_START_PROGRAM="${2:-archive}"
 printf "Inspecting Archive...\n"
 
-ROM_MOUNT="$(GET_VAR "device" "storage/rom/mount")"
-
 case "$ARCHIVE_NAME" in
 	pico-8_*)
 		if unzip -l "$ARCHIVE" | awk '
@@ -84,7 +82,7 @@ case "$ARCHIVE_NAME" in
 	*.muxapp)
 		SAFE_ARCHIVE "$ARCHIVE" || ALL_DONE 1
 
-		if ! EXTRACT_ARCHIVE "Application" "$ARCHIVE" "$ROM_MOUNT/MUOS/application"; then
+		if ! EXTRACT_ARCHIVE "Application" "$ARCHIVE" "$MUOS_STORE_DIR/application"; then
 			printf "\nExtraction Failed...\n"
 			ALL_DONE 1
 		fi


### PR DESCRIPTION
Similar to #640, I've noticed that even though Applications can now be stored on SD2 when storage preference is set to it, the archive extraction script for .muxapp always used SD1, regardless of user settings. This PR fixes that.