### PR TITLE
Send ClientID with DHCP Request

### DIFF
--- a/script/system/network.sh
+++ b/script/system/network.sh
@@ -265,7 +265,7 @@ IP_DHCP() {
 	# Fall back to udhcpc if dhcpcd not found
 	if command -v dhcpcd >/dev/null 2>&1; then
 		LOG_INFO "$0" 0 "NETWORK" "$(printf "dhcpcd was found!")"
-		dhcpcd "$IFCE" >/dev/null 2>&1 &
+		dhcpcd -I "$IFCE" >/dev/null 2>&1 &
 	elif command -v udhcpc >/dev/null 2>&1; then
 		LOG_INFO "$0" 0 "NETWORK" "$(printf "udhcpc was found!")"
 		udhcpc -i "$IFCE" -b -q >/dev/null 2>&1


### PR DESCRIPTION
I noticed with DHCP I would pull a new IP every reboot.
This change sends the ClientID so it should at least attempt to grab the old lease.
Tested and working for me.
`-I, --clientid clientid`
_Send the clientid. If the string is of the format 01:02:03 then it is encoded as hex. For interfaces whose hardware address is longer than 8 bytes, or if the clientid is an empty string then dhcpcd sends a default clientid of the hardware family and the hardware address._