### PR TITLE
Fix Left Stick inversion in SDL map

### DIFF
--- a/device/rk-g350-v/control/gamecontrollerdb/modern.txt
+++ b/device/rk-g350-v/control/gamecontrollerdb/modern.txt
@@ -1,6 +1,9 @@
 # Game Controller DB for SDL in 2.0.16 format
 # Source: https://github.com/gabomdq/SDL_GameControllerDB
 
+# Custom
+190000004b4800000300000011010000,g350_joypad,platform:Linux,x:b3,a:b0,b:b1,y:b2,back:b12,guide:b16,start:b13,dpleft:b10,dpdown:b9,dpright:b11,dpup:b8,leftshoulder:b4,lefttrigger:b6,rightshoulder:b5,righttrigger:b7,leftstick:b14,rightstick:b15,leftx:a0~,lefty:a2~,rightx:a3,righty:a1,
+
 # Windows
 03000000fa2d00000100000000000000,3dRudder Foot Motion Controller,leftx:a0,lefty:a1,rightx:a5,righty:a2,platform:Windows,
 03000000d0160000040d000000000000,4Play Adapter,a:b1,b:b3,back:b4,dpdown:b11,dpleft:b12,dpright:b13,dpup:b10,leftshoulder:b6,leftstick:b14,lefttrigger:b8,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b15,righttrigger:b9,rightx:a3,righty:a4,start:b5,x:b0,y:b2,platform:Windows,
@@ -925,8 +928,8 @@ xinput,XInput Controller,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,
 
 # Linux
 # Batlexp extra gamepads
-1900c510010000000300000011010000,batlexp_joypad,a:b0,b:b1,dpdown:b9,guide:b16,dpleft:b10,leftx:a0,lefty:a1,leftshoulder:b4,leftstick:b14,lefttrigger:b6,dpright:b11,rightx:a2,righty:a3,rightshoulder:b5,rightstick:b15,righttrigger:b7,back:b12,start:b13,dpup:b8,x:b3,y:b2,platform:Linux,
-03004ab1020500000913000010010000,Anbernic Gamepad,dpleft:h0.8,rightx:a2,dpright:h0.2,rightshoulder:b7,dpdown:h0.4,righty:a3,leftshoulder:b6,y:b4,x:b3,b:b1,a:b0,dpup:h0.1,back:b10,leftstick:b13,start:b11,lefty:a1,guide:b10,lefttrigger:a5,righttrigger:a4,rightstick:b14,leftx:a0,platform:Linux,
+1900c510010000000300000011010000,batlexp_joypad,a:b1,b:b0,dpdown:b9,guide:b16,dpleft:b10,leftx:a0,lefty:a1,leftshoulder:b4,leftstick:b14,lefttrigger:b6,dpright:b11,rightx:a2,righty:a3,rightshoulder:b5,rightstick:b15,righttrigger:b7,back:b12,start:b13,dpup:b8,x:b2,y:b3,platform:Linux,
+03004ab1020500000913000010010000,Anbernic Gamepad,dpleft:h0.8,rightx:a2,dpright:h0.2,rightshoulder:b7,dpdown:h0.4,righty:a3,leftshoulder:b6,y:b3,x:b4,b:b0,a:b1,dpup:h0.1,back:b10,leftstick:b13,start:b11,lefty:a1,guide:b10,lefttrigger:a5,righttrigger:a4,rightstick:b14,leftx:a0,platform:Linux,
 030000005e0400008e02000020010000,8BitDo Adapter,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b8,leftshoulder:b4,leftstick:b9,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b10,righttrigger:a5,rightx:a3,righty:a4,start:b7,x:b2,y:b3,platform:Linux,
 03000000c82d00000031000011010000,8BitDo Adapter,a:b0,b:b1,back:b10,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b2,leftshoulder:b6,leftstick:b13,lefttrigger:b8,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b14,righttrigger:b9,rightx:a2,righty:a3,start:b11,x:b3,y:b4,platform:Linux,
 03000000021000000090000011010000,8BitDo FC30 Pro,a:b1,b:b0,back:b10,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b6,leftstick:b13,lefttrigger:b8,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b14,righttrigger:b9,rightx:a2,righty:a3,start:b11,x:b4,y:b3,platform:Linux,
@@ -1407,8 +1410,8 @@ xinput,XInput Controller,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,
 03000000120c0000100e000011010000,Zeroplus P4,a:b1,b:b2,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b12,leftshoulder:b4,leftstick:b10,lefttrigger:a3,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:a4,rightx:a2,righty:a5,start:b9,x:b0,y:b3,platform:Linux,
 03000000120c0000101e000011010000,Zeroplus P4,a:b1,b:b2,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b12,leftshoulder:b4,leftstick:b10,lefttrigger:a3,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:a4,rightx:a2,righty:a5,start:b9,x:b0,y:b3,platform:Linux,
 19000000010000000100000000010000,RG35XX Gamepad,a:b0,b:b1,x:b2,y:b3,leftshoulder:b4,rightshoulder:b5,lefttrigger:b6,righttrigger:b7,guide:b8,start:b9,back:b10,dpup:b13,dpleft:b15,dpright:b16,dpdown:b14,volumedown:b11,volumeup:b12,platform:Linux,
-19000000010000000100000000010000,Deeplay-keys,a:b4,b:b3,x:b5,y:b6,leftshoulder:b7,rightshoulder:b8,lefttrigger:b13,righttrigger:b14,guide:b11,start:b10,back:b9,dpup:h0.1,dpleft:h0.8,dpright:h0.2,dpdown:h0.4,volumedown:b1,volumeup:b2,leftx:a0,lefty:a1,leftstick:b12,rightx:a2,righty:a3,rightstick:b15,platform:Linux,
-19000000010000000100000000010000,muOS-Keys,a:b4,b:b3,x:b5,y:b6,leftshoulder:b7,rightshoulder:b8,lefttrigger:b13,righttrigger:b14,guide:b11,start:b10,back:b9,dpup:h0.1,dpleft:h0.8,dpright:h0.2,dpdown:h0.4,volumedown:b1,volumeup:b2,leftx:a0,lefty:a1,leftstick:b12,rightx:a2,righty:a3,rightstick:b15,platform:Linux,
+19000000010000000100000000010000,Deeplay-keys,a:b3,b:b4,x:b6,y:b5,leftshoulder:b7,rightshoulder:b8,lefttrigger:b13,righttrigger:b14,guide:b11,start:b10,back:b9,dpup:h0.1,dpleft:h0.8,dpright:h0.2,dpdown:h0.4,volumedown:b1,volumeup:b2,leftx:a0,lefty:a1,leftstick:b12,rightx:a2,righty:a3,rightstick:b15,platform:Linux,
+19000000010000000100000000010000,muOS-Keys,a:b3,b:b4,x:b6,y:b5,leftshoulder:b7,rightshoulder:b8,lefttrigger:b13,righttrigger:b14,guide:b11,start:b10,back:b9,dpup:h0.1,dpleft:h0.8,dpright:h0.2,dpdown:h0.4,volumedown:b1,volumeup:b2,leftx:a0,lefty:a1,leftstick:b12,rightx:a2,righty:a3,rightstick:b15,platform:Linux,
 
 # Android
 38653964633230666463343334313533,8BitDo Adapter,a:b0,b:b1,back:b15,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b9,leftstick:b7,lefttrigger:b17,leftx:a0,lefty:a1,rightshoulder:b10,rightstick:b8,righttrigger:b18,rightx:a2,righty:a3,start:b6,x:b2,y:b3,platform:Android,

--- a/device/rk-g350-v/control/gamecontrollerdb/retro.txt
+++ b/device/rk-g350-v/control/gamecontrollerdb/retro.txt
@@ -1,6 +1,9 @@
 # Game Controller DB for SDL in 2.0.16 format
 # Source: https://github.com/gabomdq/SDL_GameControllerDB
 
+# Custom
+190000004b4800000300000011010000,g350_joypad,platform:Linux,x:b2,a:b1,b:b0,y:b3,back:b12,guide:b16,start:b13,dpleft:b10,dpdown:b9,dpright:b11,dpup:b8,leftshoulder:b4,lefttrigger:b6,rightshoulder:b5,righttrigger:b7,leftstick:b14,rightstick:b15,leftx:a0~,lefty:a2~,rightx:a3,righty:a1,
+
 # Windows
 03000000fa2d00000100000000000000,3dRudder Foot Motion Controller,leftx:a0,lefty:a1,rightx:a5,righty:a2,platform:Windows,
 03000000d0160000040d000000000000,4Play Adapter,a:b1,b:b3,back:b4,dpdown:b11,dpleft:b12,dpright:b13,dpup:b10,leftshoulder:b6,leftstick:b14,lefttrigger:b8,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b15,righttrigger:b9,rightx:a3,righty:a4,start:b5,x:b0,y:b2,platform:Windows,


### PR DESCRIPTION
So in `gamecontrollerdb.txt` when I ran sdljoymap it gave me `leftx:a0,lefty:a2`
I was inverting that by trying `leftx:-a0,lefty:-a2`. Apparently this is wrong as it treats it like a mathematical operator, so even though the axes inverted the range calcs get fucked up.
The correct and working way is `leftx:a0~,lefty:a2~`.
By applying the `~` after the axis it acts like an inversion hint and SDL just inverts the axis without breaking the math.