### PR TITLE
Disabled console logging to fix stutter

### DIFF
--- a/script/init/async/S01init.sh
+++ b/script/init/async/S01init.sh
@@ -12,6 +12,9 @@ DO_START() {
 	LOG_INFO "$0" 0 "BOOTING" "Creating Required Run Directory"
 	mkdir -p "$MUOS_RUN_DIR"
 
+	# Set console_loglevel to 0 unless debug mode is enabled
+	[ "$DEBUG_MODE" != "1" ] && printf "0" >/proc/sys/kernel/printk
+
 	grep -qE "defaults\.(ctl|pcm)\.card [1-9]" /usr/share/alsa/alsa.conf 2>/dev/null && \
 		sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.conf
 

--- a/script/init/async/S01init.sh
+++ b/script/init/async/S01init.sh
@@ -13,7 +13,7 @@ DO_START() {
 	mkdir -p "$MUOS_RUN_DIR"
 
 	# Set console_loglevel to 0 unless debug mode is enabled
-	[ "$DEBUG_MODE" != "1" ] && printf "0" >/proc/sys/kernel/printk
+	[ "$(GET_DEBUG)" -eq 0 ] && printf "%d" 0 >/proc/sys/kernel/printk
 
 	grep -qE "defaults\.(ctl|pcm)\.card [1-9]" /usr/share/alsa/alsa.conf 2>/dev/null && \
 		sed -i -E "s/(defaults\.(ctl|pcm)\.card) [0-9]+/\1 0/g" /usr/share/alsa/alsa.conf

--- a/script/mux/frontend.sh
+++ b/script/mux/frontend.sh
@@ -54,7 +54,7 @@ if [ "$SKIP" = "0" ]; then
 	esac
 fi
 
-if IS_ONE "$DEBUG_MODE"; then
+if [ "$(GET_DEBUG)" -gt 0 ]; then
 	BL_PATH="$ROM_MOUNT/MUOS/log/boot"
 	mkdir -p "$BL_PATH"
 	cp "$MUOS_LOG_DIR"/*.log "$BL_PATH"/. 2>/dev/null

--- a/script/var/func.sh
+++ b/script/var/func.sh
@@ -638,13 +638,25 @@ PARSE_INI() {
 	sed -n "/^\[$SECTION\]/ { :l /^${KEY}[ ]*=[ ]*/ { s/^[^=]*=[ ]*//; p; q; }; n; b l; }" "${INI_FILE}"
 }
 
-# Read debug_mode directly to skip a GET_VAR fork on every script source
-DEBUG_MODE=0
-[ -r "$MUOS_CONF_SYSTEM/debug_mode" ] && IFS= read -r DEBUG_MODE <"$MUOS_CONF_SYSTEM/debug_mode" 2>/dev/null
-DEBUG_MODE=${DEBUG_MODE%"$CR"}
-[ "$DEBUG_MODE" = "1" ] || DEBUG_MODE=0
+GET_DEBUG() {
+	DEBUG_MODE=0
 
-if [ "$DEBUG_MODE" -eq 1 ]; then
+	[ -r "$MUOS_CONF_SYSTEM/debug_mode" ] && {
+		IFS= read -r DEBUG_MODE <"$MUOS_CONF_SYSTEM/debug_mode" 2>/dev/null
+	}
+
+	DEBUG_MODE=${DEBUG_MODE%"$CR"}
+
+	case "$DEBUG_MODE" in
+		''|*[!0-9]*)
+			DEBUG_MODE=0
+			;;
+	esac
+
+	printf "%d" "$DEBUG_MODE"
+}
+
+if [ "$(GET_DEBUG)" -gt 0 ]; then
 	LOG_INFO() {
 		"$MUOS_LOG_BIN" info "$@"
 	}


### PR DESCRIPTION
This doesn't affect the kernel ring buffer viewed with dmesg.