### PR TITLE
Add default hint to asound.conf

### DIFF
--- a/share/conf/asound.conf
+++ b/share/conf/asound.conf
@@ -3,6 +3,10 @@ pcm.!default {
     slave.pcm {
         type pipewire
     }
+    hint {
+        show on
+        description "Default ALSA Output (PipeWire)"
+    }
 }
 
 ctl.!default {


### PR DESCRIPTION
Apps that pick an output by walking `snd_device_name_hint` (FMOD, and some SDL paths) can't see default because the override omits the hint. This restores the enumeration. Validated on RG40XXH.